### PR TITLE
Implement support for writing complex types

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,4 +38,6 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
+        env:
+          RUN_SLOW_TESTS: true
         run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ pkg/
 profile.json
 **/*.parquet
 !test/*.parquet
+
+*.py
+*.txt
+.cursorrules
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a06d507f54b70a277be22a127c8ffe0cec6cd98c0ad8a48e77779bbda8223"
+checksum = "57a4a6d2896083cfbdf84a71a863b22460d0708f8206a8373c52e326cc72ea1a"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69d326d5ad1cb82dcefa9ede3fee8fdca98f9982756b16f9cb142f4aa6edc89"
+checksum = "cef870583ce5e4f3b123c181706f2002fb134960f9a911900f64ba4830c7a43a"
 dependencies = [
  "bytes",
  "half",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626e65bd42636a84a238bed49d09c8777e3d825bf81f5087a70111c2831d9870"
+checksum = "1ac7eba5a987f8b4a7d9629206ba48e19a1991762795bbe5d08497b7736017ee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1858e7c7d01c44cf71c21a85534fd1a54501e8d60d1195d0d6fbcc00f4b10754"
+checksum = "b095e8a4f3c309544935d53e04c3bfe4eea4e71c3de6fe0416d1f08bb4441a83"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bb3f727f049884c7603f0364bc9315363f356b59e9f605ea76541847e06a1e"
+checksum = "65c63da4afedde2b25ef69825cd4663ca76f78f79ffe2d057695742099130ff6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -135,15 +135,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105f01ec0090259e9a33a9263ec18ff223ab91a0ea9fbc18042f7e38005142f6"
+checksum = "0f40f6be8f78af1ab610db7d9b236e21d587b7168e368a36275d2e5670096735"
 
 [[package]]
 name = "arrow-select"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f690752fdbd2dee278b5f1636fefad8f2f7134c85e20fd59c4199e15a39a6807"
+checksum = "ac265273864a820c4a179fc67182ccc41ea9151b97024e1be956f0f2369c2539"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -247,9 +247,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -273,14 +273,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -337,9 +337,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "errno"
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.1.29"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
+checksum = "3590fea8e9e22d449600c9bbd481a8163bef223e4ff938e5f55899f8cf1adb93"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -660,9 +660,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lz4_flex"
@@ -719,9 +719,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "ordered-float"
@@ -833,12 +833,13 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "bytes",
+ "either",
  "itertools 0.14.0",
  "jemallocator",
  "jiff",
  "magnus",
  "mimalloc",
- "parquet 54.1.0",
+ "parquet 54.2.0",
  "rand",
  "rb-sys",
  "simdutf8",
@@ -848,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.1.0"
+version = "54.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a01a0efa30bbd601ae85b375c728efdb211ade54390281628a7b16708beb235"
+checksum = "761c44d824fe83106e0600d2510c07bf4159a4985bf0569b513ea4288dc1b4fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -895,9 +896,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portable-atomic-util"
@@ -943,7 +944,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy 0.8.15",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -958,12 +959,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.15",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1079,18 +1080,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1099,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -1152,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1216,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "version_check"
@@ -1307,6 +1308,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -1402,11 +1409,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.15"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e101d4bc320b6f9abb68846837b70e25e380ca2f467ab494bf29fcc435fcc3"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
 dependencies = [
- "zerocopy-derive 0.8.15",
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -1422,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.15"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a73df1008145cd135b3c780d275c57c3e6ba8324a41bd5e0008fe167c3bc7c"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1433,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]

--- a/ext/parquet/Cargo.toml
+++ b/ext/parquet/Cargo.toml
@@ -11,15 +11,16 @@ ahash = "0.8"
 arrow-array = "54.0.0"
 arrow-schema = "54.0.0"
 bytes = "^1.9"
+either = "1.9"
 itertools = "^0.14"
-jiff = "0.1.19"
+jiff = "0.2"
 magnus = { version = "0.7", features = ["rb-sys"] }
 parquet = { version = "^54.0", features = ["json"] }
 rand = "0.9"
 rb-sys = "^0.9"
-thiserror = "2.0"
-tempfile = "^3.15"
 simdutf8 = "0.1.5"
+tempfile = "^3.15"
+thiserror = "2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/ext/parquet/src/enumerator.rs
+++ b/ext/parquet/src/enumerator.rs
@@ -7,6 +7,7 @@ pub struct RowEnumeratorArgs {
     pub result_type: ParserResultType,
     pub columns: Option<Vec<String>>,
     pub strict: bool,
+    pub logger: Option<Value>,
 }
 
 /// Creates an enumerator for lazy Parquet row parsing
@@ -22,6 +23,9 @@ pub fn create_row_enumerator(args: RowEnumeratorArgs) -> Result<magnus::Enumerat
     if args.strict {
         kwargs.aset(Symbol::new("strict"), true)?;
     }
+    if let Some(logger) = args.logger {
+        kwargs.aset(Symbol::new("logger"), logger)?;
+    }
     Ok(args
         .rb_self
         .enumeratorize("each_row", (args.to_read, KwArgs(kwargs))))
@@ -34,6 +38,7 @@ pub struct ColumnEnumeratorArgs {
     pub columns: Option<Vec<String>>,
     pub batch_size: Option<usize>,
     pub strict: bool,
+    pub logger: Option<Value>,
 }
 
 #[inline]
@@ -53,6 +58,9 @@ pub fn create_column_enumerator(
     }
     if args.strict {
         kwargs.aset(Symbol::new("strict"), true)?;
+    }
+    if let Some(logger) = args.logger {
+        kwargs.aset(Symbol::new("logger"), logger)?;
     }
     Ok(args
         .rb_self

--- a/ext/parquet/src/lib.rs
+++ b/ext/parquet/src/lib.rs
@@ -1,6 +1,7 @@
 mod allocator;
 mod enumerator;
 pub mod header_cache;
+mod logger;
 mod reader;
 mod ruby_reader;
 mod types;

--- a/ext/parquet/src/logger.rs
+++ b/ext/parquet/src/logger.rs
@@ -1,0 +1,171 @@
+// Logger module for Parquet gem
+// Provides a Rust wrapper for Ruby logger objects
+
+use std::str::FromStr;
+
+use magnus::{exception::runtime_error, value::ReprValue, Error as MagnusError, Ruby, Value};
+
+use crate::{reader::ReaderError, utils::parse_string_or_symbol};
+
+/// Severity levels that match Ruby's Logger levels
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
+}
+
+impl FromStr for LogLevel {
+    type Err = MagnusError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "debug" => LogLevel::Debug,
+            "info" => LogLevel::Info,
+            "warn" => LogLevel::Warn,
+            "error" => LogLevel::Error,
+            "fatal" => LogLevel::Fatal,
+            _ => {
+                return Err(MagnusError::new(
+                    runtime_error(),
+                    format!("Invalid log level: {}", s),
+                ))
+            }
+        })
+    }
+}
+/// A wrapper around a Ruby logger object
+#[derive(Debug, Clone)]
+pub struct RubyLogger {
+    logger: Option<Value>,
+    level: LogLevel,
+}
+
+#[allow(dead_code)]
+impl RubyLogger {
+    pub fn new(ruby: &Ruby, logger_value: Option<Value>) -> Result<Self, ReaderError> {
+        let environment_level = std::env::var("PARQUET_GEM_LOG_LEVEL")
+            .unwrap_or_else(|_| "warn".to_string())
+            .parse::<LogLevel>()
+            .unwrap_or(LogLevel::Warn);
+
+        match logger_value {
+            Some(logger) => {
+                if logger.is_nil() {
+                    return Ok(Self {
+                        logger: None,
+                        level: environment_level,
+                    });
+                }
+
+                let level_value = logger.funcall::<_, _, Value>("level", ())?;
+                let level = parse_string_or_symbol(ruby, level_value)?;
+                let level = level
+                    .map(|s| s.parse::<LogLevel>())
+                    .transpose()?
+                    .unwrap_or(environment_level);
+
+                Ok(Self {
+                    logger: Some(logger),
+                    level,
+                })
+            }
+            None => Ok(Self {
+                logger: None,
+                level: environment_level,
+            }),
+        }
+    }
+
+    /// Log a message at the given level
+    pub fn log(&self, level: LogLevel, message: &str) -> Result<(), MagnusError> {
+        let method = match level {
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+            LogLevel::Fatal => "fatal",
+        };
+
+        match self.logger {
+            Some(logger) => {
+                logger.funcall::<_, _, Value>(method, (message,))?;
+            }
+            None => eprintln!("{}", message),
+        }
+
+        Ok(())
+    }
+
+    /// Log a debug message
+    pub fn debug<F, S>(&self, message_fn: F) -> Result<(), MagnusError>
+    where
+        F: FnOnce() -> S,
+        S: AsRef<str>,
+    {
+        if self.level <= LogLevel::Debug {
+            let message = message_fn();
+            self.log(LogLevel::Debug, message.as_ref())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Log an info message
+    pub fn info<F, S>(&self, message_fn: F) -> Result<(), MagnusError>
+    where
+        F: FnOnce() -> S,
+        S: AsRef<str>,
+    {
+        if self.level <= LogLevel::Info {
+            let message = message_fn();
+            self.log(LogLevel::Info, message.as_ref())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Log a warning message
+    pub fn warn<F, S>(&self, message_fn: F) -> Result<(), MagnusError>
+    where
+        F: FnOnce() -> S,
+        S: AsRef<str>,
+    {
+        if self.level <= LogLevel::Warn {
+            let message = message_fn();
+            self.log(LogLevel::Warn, message.as_ref())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Log an error message
+    pub fn error<F, S>(&self, message_fn: F) -> Result<(), MagnusError>
+    where
+        F: FnOnce() -> S,
+        S: AsRef<str>,
+    {
+        if self.level <= LogLevel::Error {
+            let message = message_fn();
+            self.log(LogLevel::Error, message.as_ref())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Log a fatal message
+    pub fn fatal<F, S>(&self, message_fn: F) -> Result<(), MagnusError>
+    where
+        F: FnOnce() -> S,
+        S: AsRef<str>,
+    {
+        if self.level <= LogLevel::Fatal {
+            let message = message_fn();
+            self.log(LogLevel::Fatal, message.as_ref())
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/ext/parquet/src/reader/common.rs
+++ b/ext/parquet/src/reader/common.rs
@@ -1,0 +1,113 @@
+use ahash::RandomState;
+use arrow_schema::Schema;
+use either::Either;
+use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
+use parquet::arrow::ProjectionMask;
+use std::collections::HashMap;
+use std::fs::File;
+use std::sync::Arc;
+
+use magnus::value::ReprValue;
+use magnus::{Error as MagnusError, Value};
+
+use crate::header_cache::StringCache;
+use crate::ruby_reader::{RubyReader, ThreadSafeRubyReader};
+use crate::types::TryIntoValue;
+use crate::ColumnRecord;
+
+use super::ReaderError;
+
+/// Opens a parquet file or IO-like object for reading
+///
+/// This function handles both file paths (as strings) and IO-like objects,
+/// returning either a File or a ThreadSafeRubyReader that can be used with
+/// parquet readers.
+pub fn open_parquet_source(
+    to_read: Value,
+) -> Result<Either<File, ThreadSafeRubyReader>, ReaderError> {
+    let ruby = unsafe { magnus::Ruby::get_unchecked() };
+
+    if to_read.is_kind_of(ruby.class_string()) {
+        let path_string = to_read.to_r_string()?;
+        let file_path = unsafe { path_string.as_str()? };
+        let file = File::open(file_path).map_err(ReaderError::from)?;
+        Ok(Either::Left(file))
+    } else {
+        let readable = ThreadSafeRubyReader::new(RubyReader::try_from(to_read)?);
+        Ok(Either::Right(readable))
+    }
+}
+
+/// Helper function to check if a block is given and create an appropriate enumerator
+/// if not
+pub fn handle_block_or_enum<F, T>(
+    _ruby: &magnus::Ruby,
+    block_given: bool,
+    create_enum: F,
+) -> Result<Option<T>, MagnusError>
+where
+    F: FnOnce() -> Result<T, MagnusError>,
+{
+    if !block_given {
+        let enum_value = create_enum()?;
+        return Ok(Some(enum_value));
+    }
+    Ok(None)
+}
+
+/// Creates a ParquetRecordBatchReader with the given columns and batch size configurations
+pub fn create_batch_reader<T: parquet::file::reader::ChunkReader + 'static>(
+    reader: T,
+    columns: &Option<Vec<String>>,
+    batch_size: Option<usize>,
+) -> Result<(ParquetRecordBatchReader, std::sync::Arc<Schema>, i64), ReaderError> {
+    let mut builder =
+        ParquetRecordBatchReaderBuilder::try_new(reader).map_err(|e| ReaderError::Parquet(e))?;
+
+    let schema = builder.schema().clone();
+    let num_rows = builder.metadata().file_metadata().num_rows();
+
+    // If columns are specified, project only those columns
+    if let Some(cols) = columns {
+        // Get the parquet schema
+        let parquet_schema = builder.parquet_schema();
+
+        // Create a projection mask from column names
+        let projection = ProjectionMask::columns(parquet_schema, cols.iter().map(|s| s.as_str()));
+        builder = builder.with_projection(projection);
+    }
+
+    if let Some(batch_size) = batch_size {
+        builder = builder.with_batch_size(batch_size);
+    }
+
+    let reader = builder.build().map_err(|e| ReaderError::Parquet(e))?;
+    Ok((reader, schema, num_rows))
+}
+
+/// Handles the case of an empty parquet file (no rows) by yielding a record with empty arrays
+/// Returns true if the file was empty and was handled, false otherwise
+pub fn handle_empty_file(
+    ruby: &magnus::Ruby,
+    schema: &Arc<Schema>,
+    num_rows: i64,
+) -> Result<bool, ReaderError> {
+    if num_rows == 0 {
+        let mut map =
+            HashMap::with_capacity_and_hasher(schema.fields().len(), RandomState::default());
+        let headers: Vec<String> = schema
+            .fields()
+            .iter()
+            .map(|field| field.name().to_string())
+            .collect();
+        let interned_headers =
+            StringCache::intern_many(&headers).map_err(|e| ReaderError::HeaderIntern(e))?;
+        for field in interned_headers.iter() {
+            map.insert(*field, vec![]);
+        }
+        let record = ColumnRecord::Map(map);
+        let _: Value = ruby.yield_value(record.try_into_value_with(&ruby)?)?;
+        return Ok(true);
+    }
+    Ok(false)
+}

--- a/ext/parquet/src/types/core_types.rs
+++ b/ext/parquet/src/types/core_types.rs
@@ -43,16 +43,24 @@ impl std::fmt::Display for ParserResultType {
 pub struct ListField<'a> {
     pub item_type: ParquetSchemaType<'a>,
     pub format: Option<&'a str>,
+    pub nullable: bool,
 }
 
 #[derive(Debug, Clone)]
 pub struct MapField<'a> {
     pub key_type: ParquetSchemaType<'a>,
     pub value_type: ParquetSchemaType<'a>,
-    pub format: Option<&'a str>,
+    pub key_format: Option<&'a str>,
+    pub value_format: Option<&'a str>,
+    pub value_nullable: bool,
 }
 
 #[derive(Debug, Clone)]
+pub struct StructField<'a> {
+    pub fields: Vec<super::writer_types::SchemaField<'a>>,
+}
+
+#[derive(Clone, Debug)]
 pub enum ParquetSchemaType<'a> {
     Int8,
     Int16,
@@ -72,4 +80,52 @@ pub enum ParquetSchemaType<'a> {
     TimestampMicros,
     List(Box<ListField<'a>>),
     Map(Box<MapField<'a>>),
+    Struct(Box<StructField<'a>>),
+}
+
+// New schema representation for the DSL-based approach
+#[derive(Debug, Clone)]
+pub enum SchemaNode {
+    Struct {
+        name: String,
+        nullable: bool,
+        fields: Vec<SchemaNode>,
+    },
+    List {
+        name: String,
+        nullable: bool,
+        item: Box<SchemaNode>,
+    },
+    Map {
+        name: String,
+        nullable: bool,
+        key: Box<SchemaNode>,
+        value: Box<SchemaNode>,
+    },
+    Primitive {
+        name: String,
+        parquet_type: PrimitiveType,
+        nullable: bool,
+        format: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum PrimitiveType {
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+    Boolean,
+    String,
+    Binary,
+    Date32,
+    TimestampMillis,
+    TimestampMicros,
 }

--- a/ext/parquet/src/types/mod.rs
+++ b/ext/parquet/src/types/mod.rs
@@ -2,13 +2,20 @@
 mod core_types;
 mod parquet_value;
 mod record_types;
+pub mod schema_converter;
+pub mod schema_node;
 mod timestamp;
-mod type_conversion;
+pub mod type_conversion;
 mod writer_types;
 
 pub use core_types::*;
 pub use parquet_value::*;
 pub use record_types::*;
+// Explicitly export schema-related items
+pub use schema_converter::{
+    infer_schema_from_first_row, legacy_schema_to_dsl, parse_legacy_schema,
+};
+pub use schema_node::parse_schema_node;
 pub use timestamp::*;
 pub use type_conversion::*;
 pub use writer_types::*;

--- a/ext/parquet/src/types/schema_converter.rs
+++ b/ext/parquet/src/types/schema_converter.rs
@@ -1,0 +1,349 @@
+use magnus::value::ReprValue; // Add ReprValue trait to scope
+use magnus::{Error as MagnusError, RArray, Ruby, TryConvert, Value};
+
+use crate::types::{ParquetSchemaType as PST, PrimitiveType, SchemaField, SchemaNode};
+use crate::utils::parse_string_or_symbol;
+
+/// Recursively converts a SchemaField to a SchemaNode for any level of nesting
+fn convert_schema_field_to_node(field: &SchemaField) -> SchemaNode {
+    match &field.type_ {
+        PST::Int8 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Int8,
+            format: field.format.clone(),
+        },
+        PST::Int16 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Int16,
+            format: field.format.clone(),
+        },
+        PST::Int32 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Int32,
+            format: field.format.clone(),
+        },
+        PST::Int64 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Int64,
+            format: field.format.clone(),
+        },
+        PST::UInt8 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::UInt8,
+            format: field.format.clone(),
+        },
+        PST::UInt16 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::UInt16,
+            format: field.format.clone(),
+        },
+        PST::UInt32 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::UInt32,
+            format: field.format.clone(),
+        },
+        PST::UInt64 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::UInt64,
+            format: field.format.clone(),
+        },
+        PST::Float => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Float32,
+            format: field.format.clone(),
+        },
+        PST::Double => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Float64,
+            format: field.format.clone(),
+        },
+        PST::String => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::String,
+            format: field.format.clone(),
+        },
+        PST::Binary => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Binary,
+            format: field.format.clone(),
+        },
+        PST::Boolean => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Boolean,
+            format: field.format.clone(),
+        },
+        PST::Date32 => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::Date32,
+            format: field.format.clone(),
+        },
+        PST::TimestampMillis => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::TimestampMillis,
+            format: field.format.clone(),
+        },
+        PST::TimestampMicros => SchemaNode::Primitive {
+            name: field.name.clone(),
+            nullable: field.nullable,
+            parquet_type: PrimitiveType::TimestampMicros,
+            format: field.format.clone(),
+        },
+        PST::List(list_field) => {
+            // Create item node by recursively converting the list item type to a node
+            let item_node = match &list_field.item_type {
+                // For primitive types, create a primitive node with name "item"
+                PST::Int8
+                | PST::Int16
+                | PST::Int32
+                | PST::Int64
+                | PST::UInt8
+                | PST::UInt16
+                | PST::UInt32
+                | PST::UInt64
+                | PST::Float
+                | PST::Double
+                | PST::String
+                | PST::Binary
+                | PST::Boolean
+                | PST::Date32
+                | PST::TimestampMillis
+                | PST::TimestampMicros => {
+                    // Use a temporary SchemaField to convert item type
+                    let item_field = SchemaField {
+                        name: "item".to_string(),
+                        type_: list_field.item_type.clone(),
+                        format: list_field.format.clone().map(String::from),
+                        nullable: list_field.nullable,
+                    };
+                    convert_schema_field_to_node(&item_field)
+                }
+                // For nested types (List, Map, Struct), recursively convert them
+                PST::List(_) | PST::Map(_) | PST::Struct(_) => {
+                    // Use a temporary SchemaField to convert item type
+                    let item_field = SchemaField {
+                        name: "item".to_string(),
+                        type_: list_field.item_type.clone(),
+                        format: list_field.format.clone().map(String::from),
+                        nullable: list_field.nullable,
+                    };
+                    convert_schema_field_to_node(&item_field)
+                }
+            };
+
+            SchemaNode::List {
+                name: field.name.clone(),
+                nullable: field.nullable,
+                item: Box::new(item_node),
+            }
+        }
+        PST::Map(map_field) => {
+            let key_field = SchemaField {
+                name: "key".to_string(),
+                type_: map_field.key_type.clone(),
+                format: map_field.key_format.clone().map(String::from),
+                nullable: false, // Map keys can never be null in Parquet
+            };
+            let value_field = SchemaField {
+                name: "value".to_string(),
+                type_: map_field.value_type.clone(),
+                format: map_field.value_format.clone().map(String::from),
+                nullable: map_field.value_nullable,
+            };
+
+            let key_node = convert_schema_field_to_node(&key_field);
+            let value_node = convert_schema_field_to_node(&value_field);
+
+            SchemaNode::Map {
+                name: field.name.clone(),
+                nullable: field.nullable,
+                key: Box::new(key_node),
+                value: Box::new(value_node),
+            }
+        }
+        PST::Struct(struct_field) => {
+            // Convert each subfield recursively
+            let mut field_nodes = Vec::with_capacity(struct_field.fields.len());
+
+            for subfield in struct_field.fields.iter() {
+                // Recursively convert each subfield, supporting any level of nesting
+                field_nodes.push(convert_schema_field_to_node(subfield));
+            }
+
+            SchemaNode::Struct {
+                name: field.name.clone(),
+                nullable: field.nullable,
+                fields: field_nodes,
+            }
+        }
+    }
+}
+
+/// Converts the legacy schema format (array of field hashes) to the new DSL format (SchemaNode)
+pub fn legacy_schema_to_dsl(
+    _ruby: &Ruby,
+    schema_fields: Vec<SchemaField>,
+) -> Result<SchemaNode, MagnusError> {
+    // Create a top-level struct node with fields for each schema field
+    let mut field_nodes = Vec::with_capacity(schema_fields.len());
+
+    for field in schema_fields {
+        // Use our recursive converter to handle any level of nesting
+        field_nodes.push(convert_schema_field_to_node(&field));
+    }
+
+    Ok(SchemaNode::Struct {
+        name: "".to_string(), // Top level has no name
+        nullable: false,      // Top level is not nullable
+        fields: field_nodes,
+    })
+}
+
+/// Parses the legacy format schema (array of field hashes)
+pub fn parse_legacy_schema(
+    ruby: &Ruby,
+    schema_value: Value,
+) -> Result<Vec<SchemaField>, MagnusError> {
+    if schema_value.is_nil()
+        || (schema_value.is_kind_of(ruby.class_array())
+            && RArray::from_value(schema_value)
+                .ok_or_else(|| {
+                    MagnusError::new(
+                        ruby.exception_type_error(),
+                        "Schema must be an array of field definitions or nil",
+                    )
+                })?
+                .len()
+                == 0)
+    {
+        // If schema is nil or an empty array, we'll handle this in the caller
+        return Ok(Vec::new());
+    }
+
+    if schema_value.is_kind_of(ruby.class_array()) {
+        let schema_array = RArray::from_value(schema_value).ok_or_else(|| {
+            MagnusError::new(
+                ruby.exception_type_error(),
+                "Schema must be an array of field definitions or nil",
+            )
+        })?;
+        let mut schema = Vec::with_capacity(schema_array.len());
+
+        for (idx, field_hash) in schema_array.into_iter().enumerate() {
+            if !field_hash.is_kind_of(ruby.class_hash()) {
+                return Err(MagnusError::new(
+                    ruby.exception_type_error(),
+                    format!("schema[{}] must be a hash", idx),
+                ));
+            }
+
+            let entries: Vec<(Value, Value)> = field_hash.funcall("to_a", ())?;
+            if entries.len() != 1 {
+                return Err(MagnusError::new(
+                    ruby.exception_type_error(),
+                    format!("schema[{}] must contain exactly one key-value pair", idx),
+                ));
+            }
+
+            let (name, type_value) = &entries[0];
+            let name_option = parse_string_or_symbol(ruby, name.clone())?;
+            let name = name_option.ok_or_else(|| {
+                MagnusError::new(ruby.exception_runtime_error(), "Field name cannot be nil")
+            })?;
+
+            let (type_, format, nullable) = if type_value.is_kind_of(ruby.class_hash()) {
+                let type_hash: Vec<(Value, Value)> = type_value.funcall("to_a", ())?;
+                let mut type_str = None;
+                let mut format_str = None;
+                let mut nullable = true; // Default to true if not specified
+
+                for (key, value) in type_hash {
+                    let key_option = parse_string_or_symbol(ruby, key)?;
+                    let key = key_option.ok_or_else(|| {
+                        MagnusError::new(ruby.exception_runtime_error(), "Type key cannot be nil")
+                    })?;
+                    match key.as_str() {
+                        "type" => type_str = Some(value),
+                        "format" => {
+                            let format_option = parse_string_or_symbol(ruby, value)?;
+                            format_str = format_option;
+                        }
+                        "nullable" => {
+                            // Extract nullable if present - convert to boolean
+                            nullable = bool::try_convert(value).unwrap_or(true);
+                        }
+                        _ => {
+                            return Err(MagnusError::new(
+                                ruby.exception_type_error(),
+                                format!("Unknown key '{}' in type definition", key),
+                            ))
+                        }
+                    }
+                }
+
+                let type_str = type_str.ok_or_else(|| {
+                    MagnusError::new(
+                        ruby.exception_type_error(),
+                        "Missing 'type' in type definition",
+                    )
+                })?;
+
+                (PST::try_convert(type_str)?, format_str, nullable)
+            } else {
+                (PST::try_convert(type_value.clone())?, None, true)
+            };
+
+            schema.push(SchemaField {
+                name,
+                type_,
+                format,
+                nullable,
+            });
+        }
+
+        Ok(schema)
+    } else {
+        Err(MagnusError::new(
+            ruby.exception_type_error(),
+            "Schema must be an array of field definitions or nil",
+        ))
+    }
+}
+
+/// Generates schema fields by inferring from the first row
+pub fn infer_schema_from_first_row(
+    ruby: &Ruby,
+    first_value: Value,
+    nullable: bool,
+) -> Result<Vec<SchemaField>, MagnusError> {
+    let array = RArray::from_value(first_value).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_type_error(),
+            "First value must be an array when schema is not provided",
+        )
+    })?;
+
+    // Generate field names f0, f1, f2, etc.
+    Ok((0..array.len())
+        .map(|i| SchemaField {
+            name: format!("f{}", i),
+            type_: PST::String, // Default to String type when inferring
+            format: None,
+            nullable,
+        })
+        .collect())
+}

--- a/ext/parquet/src/types/schema_node.rs
+++ b/ext/parquet/src/types/schema_node.rs
@@ -1,0 +1,329 @@
+use std::sync::Arc;
+
+use arrow_schema::{
+    DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
+};
+use magnus::{Error as MagnusError, RArray, RHash, Ruby, Symbol, TryConvert, Value};
+
+use crate::logger::RubyLogger;
+use crate::types::{PrimitiveType, SchemaNode};
+use crate::utils::parse_string_or_symbol;
+
+/// Builds an Arrow schema from a SchemaNode tree - placeholder declaration
+/// The actual implementation appears later in the file
+fn _build_arrow_schema_placeholder() {}
+
+/// Helper to extract common fields from a schema node hash
+fn extract_common_fields(
+    ruby: &Ruby,
+    node_hash: &RHash,
+) -> Result<(String, bool, Option<String>), MagnusError> {
+    // extract `name:` if present, else default
+    let name_val = node_hash.get(Symbol::new("name"));
+    let name: String = if let Some(v) = name_val {
+        let name_option = parse_string_or_symbol(ruby, v)?;
+        name_option.unwrap_or_else(|| "".to_string())
+    } else {
+        "".to_string() // top-level might omit name
+    };
+
+    // extract `nullable:`
+    let nullable_val = node_hash.get(Symbol::new("nullable"));
+    let nullable: bool = if let Some(v) = nullable_val {
+        bool::try_convert(v).unwrap_or(true)
+    } else {
+        true // default to nullable
+    };
+
+    // optional `format:`
+    let format_val = node_hash.get(Symbol::new("format"));
+    let format: Option<String> = if let Some(v) = format_val {
+        parse_string_or_symbol(ruby, v)?
+    } else {
+        None
+    };
+
+    Ok((name, nullable, format))
+}
+
+/// Parse a struct schema node
+fn parse_struct_node(
+    ruby: &Ruby,
+    node_hash: &RHash,
+    name: String,
+    nullable: bool,
+) -> Result<SchemaNode, MagnusError> {
+    // parse subfields array from `fields`
+    let fields_val = node_hash.get(Symbol::new("fields")).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "Struct must have :fields array defined",
+        )
+    })?;
+    let fields_arr: RArray = RArray::try_convert(fields_val).map_err(|_| {
+        MagnusError::new(
+            ruby.exception_type_error(),
+            "The :fields value must be an array",
+        )
+    })?;
+
+    // Check for empty struct immediately
+    if fields_arr.len() == 0 {
+        return Err(MagnusError::new(
+            ruby.exception_arg_error(),
+            format!("Cannot create a struct with zero fields. Struct name: '{}'. Parquet doesn't support empty structs", name)
+        ));
+    }
+
+    let mut fields = Vec::with_capacity(fields_arr.len());
+    for item in fields_arr.into_iter() {
+        fields.push(parse_schema_node(ruby, item)?);
+    }
+
+    Ok(SchemaNode::Struct {
+        name,
+        nullable,
+        fields,
+    })
+}
+
+/// Parse a list schema node
+fn parse_list_node(
+    ruby: &Ruby,
+    node_hash: &RHash,
+    name: String,
+    nullable: bool,
+) -> Result<SchemaNode, MagnusError> {
+    // parse `item`
+    let item_val = node_hash.get(Symbol::new("item")).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "List type must have :item field defined",
+        )
+    })?;
+    let item_node = parse_schema_node(ruby, item_val)?;
+
+    Ok(SchemaNode::List {
+        name,
+        nullable,
+        item: Box::new(item_node),
+    })
+}
+
+/// Parse a map schema node
+fn parse_map_node(
+    ruby: &Ruby,
+    node_hash: &RHash,
+    name: String,
+    nullable: bool,
+) -> Result<SchemaNode, MagnusError> {
+    // parse `key` and `value`
+    let key_val = node_hash.get(Symbol::new("key")).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "Map type must have :key field defined",
+        )
+    })?;
+    let value_val = node_hash.get(Symbol::new("value")).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "Map type must have :value field defined",
+        )
+    })?;
+
+    let key_node = parse_schema_node(ruby, key_val)?;
+    let value_node = parse_schema_node(ruby, value_val)?;
+
+    Ok(SchemaNode::Map {
+        name,
+        nullable,
+        key: Box::new(key_node),
+        value: Box::new(value_node),
+    })
+}
+
+/// Parse a Ruby schema hash into a SchemaNode tree
+pub fn parse_schema_node(ruby: &Ruby, node_value: Value) -> Result<SchemaNode, MagnusError> {
+    // The node_value should be a Ruby Hash with keys: :name, :type, :nullable, etc.
+    let node_hash = RHash::from_value(node_value).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_type_error(),
+            "Schema node must be a Hash with :type and other fields",
+        )
+    })?;
+
+    // extract `type:` which is a symbol/string
+    let type_val = node_hash.get(Symbol::new("type")).ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "Missing required :type field in schema node",
+        )
+    })?;
+    let type_str_option = parse_string_or_symbol(ruby, type_val)?;
+    let type_str = type_str_option.ok_or_else(|| {
+        MagnusError::new(
+            ruby.exception_arg_error(),
+            "Type cannot be nil - please specify a valid type string or symbol",
+        )
+    })?;
+
+    // Extract common fields (name, nullable, format)
+    let (name, nullable, format) = extract_common_fields(ruby, &node_hash)?;
+
+    // Delegate to type-specific parsers with clear error handling
+    match type_str.as_str() {
+        "struct" => parse_struct_node(ruby, &node_hash, name, nullable),
+        "list" => parse_list_node(ruby, &node_hash, name, nullable),
+        "map" => parse_map_node(ruby, &node_hash, name, nullable),
+        // For primitives, provide better error messages when type isn't recognized
+        other => {
+            if let Some(parquet_type) = parse_primitive_type(other) {
+                Ok(SchemaNode::Primitive {
+                    name,
+                    parquet_type,
+                    nullable,
+                    format,
+                })
+            } else {
+                Err(MagnusError::new(
+                    magnus::exception::arg_error(),
+                    format!(
+                        "Unknown type: '{}'. Supported types are: struct, list, map, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64, boolean, string, binary, date32, timestamp_millis, timestamp_micros",
+                        other
+                    )
+                ))
+            }
+        }
+    }
+}
+
+/// Convert a type string like "int32" to a PrimitiveType
+fn parse_primitive_type(s: &str) -> Option<PrimitiveType> {
+    match s.to_lowercase().as_str() {
+        "int8" | "i8" => Some(PrimitiveType::Int8),
+        "int16" | "i16" => Some(PrimitiveType::Int16),
+        "int32" | "i32" | "int" => Some(PrimitiveType::Int32),
+        "int64" | "i64" | "long" | "bigint" => Some(PrimitiveType::Int64),
+        "uint8" | "u8" | "byte" => Some(PrimitiveType::UInt8),
+        "uint16" | "u16" => Some(PrimitiveType::UInt16),
+        "uint32" | "u32" | "uint" => Some(PrimitiveType::UInt32),
+        "uint64" | "u64" | "ulong" => Some(PrimitiveType::UInt64),
+        "float" | "float32" | "f32" => Some(PrimitiveType::Float32),
+        "double" | "float64" | "f64" => Some(PrimitiveType::Float64),
+        "bool" | "boolean" => Some(PrimitiveType::Boolean),
+        "string" | "utf8" | "str" | "text" => Some(PrimitiveType::String),
+        "binary" | "bytes" | "blob" => Some(PrimitiveType::Binary),
+        "date" | "date32" => Some(PrimitiveType::Date32),
+        "timestamp_millis" | "timestamp_ms" => Some(PrimitiveType::TimestampMillis),
+        "timestamp_micros" | "timestamp_us" => Some(PrimitiveType::TimestampMicros),
+        _ => None,
+    }
+}
+
+/// Convert a SchemaNode to an Arrow field
+pub fn schema_node_to_arrow_field(node: &SchemaNode) -> ArrowField {
+    match node {
+        SchemaNode::Primitive {
+            name,
+            parquet_type,
+            nullable,
+            format: _,
+        } => {
+            let dt = match parquet_type {
+                PrimitiveType::Int8 => ArrowDataType::Int8,
+                PrimitiveType::Int16 => ArrowDataType::Int16,
+                PrimitiveType::Int32 => ArrowDataType::Int32,
+                PrimitiveType::Int64 => ArrowDataType::Int64,
+                PrimitiveType::UInt8 => ArrowDataType::UInt8,
+                PrimitiveType::UInt16 => ArrowDataType::UInt16,
+                PrimitiveType::UInt32 => ArrowDataType::UInt32,
+                PrimitiveType::UInt64 => ArrowDataType::UInt64,
+                PrimitiveType::Float32 => ArrowDataType::Float32,
+                PrimitiveType::Float64 => ArrowDataType::Float64,
+                PrimitiveType::Boolean => ArrowDataType::Boolean,
+                PrimitiveType::String => ArrowDataType::Utf8,
+                PrimitiveType::Binary => ArrowDataType::Binary,
+                PrimitiveType::Date32 => ArrowDataType::Date32,
+                PrimitiveType::TimestampMillis => {
+                    ArrowDataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None)
+                }
+                PrimitiveType::TimestampMicros => {
+                    ArrowDataType::Timestamp(arrow_schema::TimeUnit::Microsecond, None)
+                }
+            };
+            ArrowField::new(name, dt, *nullable)
+        }
+
+        SchemaNode::List {
+            name,
+            nullable,
+            item,
+        } => {
+            let child_field = schema_node_to_arrow_field(item);
+            let list_type = ArrowDataType::List(Arc::new(child_field));
+            ArrowField::new(name, list_type, *nullable)
+        }
+
+        SchemaNode::Map {
+            name,
+            nullable,
+            key,
+            value,
+        } => {
+            // A Map is basically: Map( Struct([key, value]), keysSorted=false )
+            let key_field = schema_node_to_arrow_field(key);
+            let value_field = schema_node_to_arrow_field(value);
+
+            let entries_struct = ArrowDataType::Struct(ArrowFields::from(vec![
+                ArrowField::new("key", key_field.data_type().clone(), false),
+                ArrowField::new(
+                    "value",
+                    value_field.data_type().clone(),
+                    value_field.is_nullable(),
+                ),
+            ]));
+
+            let map_data_type = ArrowDataType::Map(
+                Arc::new(ArrowField::new("entries", entries_struct, false)),
+                false, // not sorted
+            );
+            ArrowField::new(name, map_data_type, *nullable)
+        }
+
+        SchemaNode::Struct {
+            name,
+            nullable,
+            fields,
+        } => {
+            // Field validation happens earlier - no empty structs allowed
+            let mut arrow_subfields = Vec::with_capacity(fields.len());
+            for f in fields {
+                arrow_subfields.push(schema_node_to_arrow_field(f));
+            }
+            let struct_type = ArrowDataType::Struct(ArrowFields::from(arrow_subfields));
+            ArrowField::new(name, struct_type, *nullable)
+        }
+    }
+}
+
+/// Build an Arrow schema from the top-level Node, which must be a Struct
+pub fn build_arrow_schema(
+    root: &SchemaNode,
+    logger: &RubyLogger,
+) -> Result<Arc<ArrowSchema>, MagnusError> {
+    match root {
+        SchemaNode::Struct { fields, .. } => {
+            // Fields debug output removed - we've fixed the empty struct issue
+
+            let arrow_fields: Vec<ArrowField> =
+                fields.iter().map(schema_node_to_arrow_field).collect();
+            let arrow_schema = ArrowSchema::new(arrow_fields);
+            logger.debug(|| format!("Constructed Arrow schema: {:?}", arrow_schema))?;
+            Ok(Arc::new(arrow_schema))
+        }
+        _ => Err(MagnusError::new(
+            magnus::exception::arg_error(),
+            "Top-level schema must be a Struct".to_owned(),
+        )),
+    }
+}

--- a/ext/parquet/src/types/writer_types.rs
+++ b/ext/parquet/src/types/writer_types.rs
@@ -1,32 +1,36 @@
+use super::core_types::SchemaNode;
+use crate::{
+    reader::ReaderError,
+    types::{ListField, MapField, ParquetSchemaType},
+};
+use arrow_array::{Array, RecordBatch};
+use magnus::{value::ReprValue, Error as MagnusError, RString, Ruby, Symbol, TryConvert, Value};
+use parquet::{arrow::ArrowWriter, errors::ParquetError};
 use std::{
     io::{self, Write},
     str::FromStr,
     sync::Arc,
 };
-
-use arrow_array::{Array, RecordBatch};
-use magnus::{value::ReprValue, Error as MagnusError, RString, Ruby, Symbol, TryConvert, Value};
-use parquet::{arrow::ArrowWriter, errors::ParquetError};
 use tempfile::NamedTempFile;
 
-use crate::types::{convert_to_string, ListField, MapField, ParquetSchemaType};
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SchemaField<'a> {
     pub name: String,
     pub type_: ParquetSchemaType<'a>,
     pub format: Option<String>,
+    pub nullable: bool,
 }
 
 #[derive(Debug)]
-pub struct ParquetWriteArgs<'a> {
+pub struct ParquetWriteArgs {
     pub read_from: Value,
     pub write_to: Value,
-    pub schema: Vec<SchemaField<'a>>,
+    pub schema: SchemaNode,
     pub batch_size: Option<usize>,
     pub flush_threshold: Option<usize>,
     pub compression: Option<String>,
     pub sample_size: Option<usize>,
+    pub logger: Option<Value>,
 }
 
 pub trait SendableWrite: Send + Write {}
@@ -59,6 +63,42 @@ impl<'a> FromStr for ParquetSchemaType<'a> {
     type Err = MagnusError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Check if it's a list type
+        if let Some(inner_type_str) = s.strip_prefix("list<").and_then(|s| s.strip_suffix(">")) {
+            let inner_type = inner_type_str.parse::<ParquetSchemaType>()?;
+            return Ok(ParquetSchemaType::List(Box::new(ListField {
+                item_type: inner_type,
+                format: None,
+                nullable: true,
+            })));
+        }
+
+        // Check if it's a map type
+        if let Some(kv_types_str) = s.strip_prefix("map<").and_then(|s| s.strip_suffix(">")) {
+            let parts: Vec<&str> = kv_types_str.splitn(2, ',').collect();
+            if parts.len() != 2 {
+                return Err(MagnusError::new(
+                    magnus::exception::runtime_error(),
+                    format!(
+                        "Invalid map format. Expected 'map<keyType,valueType>', got '{}'",
+                        s
+                    ),
+                ));
+            }
+
+            let key_type = parts[0].trim().parse::<ParquetSchemaType>()?;
+            let value_type = parts[1].trim().parse::<ParquetSchemaType>()?;
+
+            return Ok(ParquetSchemaType::Map(Box::new(MapField {
+                key_type,
+                value_type,
+                key_format: None,
+                value_format: None,
+                value_nullable: true,
+            })));
+        }
+
+        // Handle primitive types
         match s {
             "int8" => Ok(ParquetSchemaType::Int8),
             "int16" => Ok(ParquetSchemaType::Int16),
@@ -77,13 +117,16 @@ impl<'a> FromStr for ParquetSchemaType<'a> {
             "timestamp_millis" => Ok(ParquetSchemaType::TimestampMillis),
             "timestamp_micros" => Ok(ParquetSchemaType::TimestampMicros),
             "list" => Ok(ParquetSchemaType::List(Box::new(ListField {
-                item_type: ParquetSchemaType::Int8,
+                item_type: ParquetSchemaType::String,
                 format: None,
+                nullable: true,
             }))),
             "map" => Ok(ParquetSchemaType::Map(Box::new(MapField {
                 key_type: ParquetSchemaType::String,
-                value_type: ParquetSchemaType::Int8,
-                format: None,
+                value_type: ParquetSchemaType::String,
+                key_format: None,
+                value_format: None,
+                value_nullable: true,
             }))),
             _ => Err(MagnusError::new(
                 magnus::exception::runtime_error(),
@@ -98,7 +141,11 @@ impl<'a> TryConvert for ParquetSchemaType<'a> {
         let ruby = unsafe { Ruby::get_unchecked() };
         let schema_type = parse_string_or_symbol(&ruby, value)?;
 
-        schema_type.unwrap().parse()
+        schema_type
+            .ok_or_else(|| {
+                MagnusError::new(magnus::exception::type_error(), "Invalid schema type")
+            })?
+            .parse()
     }
 }
 
@@ -157,126 +204,50 @@ impl WriterOutput {
     }
 }
 
-pub struct ParquetErrorWrapper(pub ParquetError);
-
-impl From<ParquetErrorWrapper> for MagnusError {
-    fn from(err: ParquetErrorWrapper) -> Self {
-        MagnusError::new(
-            magnus::exception::runtime_error(),
-            format!("Parquet error: {}", err.0),
-        )
-    }
-}
-
 pub struct ColumnCollector<'a> {
     pub name: String,
     pub type_: ParquetSchemaType<'a>,
     pub format: Option<String>,
+    pub nullable: bool,
     pub values: Vec<crate::types::ParquetValue>,
 }
 
 impl<'a> ColumnCollector<'a> {
-    pub fn new(name: String, type_: ParquetSchemaType<'a>, format: Option<String>) -> Self {
+    pub fn new(
+        name: String,
+        type_: ParquetSchemaType<'a>,
+        format: Option<String>,
+        nullable: bool,
+    ) -> Self {
         Self {
             name,
             type_,
             format,
+            nullable,
             values: Vec::new(),
         }
     }
 
     pub fn push_value(&mut self, value: Value) -> Result<(), MagnusError> {
         use crate::types::ParquetValue;
-        use crate::{
-            convert_to_binary, convert_to_boolean, convert_to_date32, convert_to_list,
-            convert_to_map, convert_to_timestamp_micros, convert_to_timestamp_millis,
-            NumericConverter,
-        };
 
         if value.is_nil() {
-            self.values.push(ParquetValue::Null);
-            return Ok(());
+            if !self.nullable {
+                // For non-nullable fields, raise an error
+                return Err(MagnusError::new(
+                    magnus::exception::runtime_error(),
+                    "Cannot write nil value for non-nullable field",
+                ));
+            }
         }
 
-        let parquet_value = match &self.type_ {
-            ParquetSchemaType::Int8 => {
-                let v = NumericConverter::<i8>::convert_with_string_fallback(value)?;
-                ParquetValue::Int8(v)
-            }
-            ParquetSchemaType::Int16 => {
-                let v = NumericConverter::<i16>::convert_with_string_fallback(value)?;
-                ParquetValue::Int16(v)
-            }
-            ParquetSchemaType::Int32 => {
-                let v = NumericConverter::<i32>::convert_with_string_fallback(value)?;
-                ParquetValue::Int32(v)
-            }
-            ParquetSchemaType::Int64 => {
-                let v = NumericConverter::<i64>::convert_with_string_fallback(value)?;
-                ParquetValue::Int64(v)
-            }
-            ParquetSchemaType::UInt8 => {
-                let v = NumericConverter::<u8>::convert_with_string_fallback(value)?;
-                ParquetValue::UInt8(v)
-            }
-            ParquetSchemaType::UInt16 => {
-                let v = NumericConverter::<u16>::convert_with_string_fallback(value)?;
-                ParquetValue::UInt16(v)
-            }
-            ParquetSchemaType::UInt32 => {
-                let v = NumericConverter::<u32>::convert_with_string_fallback(value)?;
-                ParquetValue::UInt32(v)
-            }
-            ParquetSchemaType::UInt64 => {
-                let v = NumericConverter::<u64>::convert_with_string_fallback(value)?;
-                ParquetValue::UInt64(v)
-            }
-            ParquetSchemaType::Float => {
-                let v = NumericConverter::<f32>::convert_with_string_fallback(value)?;
-                ParquetValue::Float32(v)
-            }
-            ParquetSchemaType::Double => {
-                let v = NumericConverter::<f64>::convert_with_string_fallback(value)?;
-                ParquetValue::Float64(v)
-            }
-            ParquetSchemaType::String => {
-                let v = convert_to_string(value)?;
-                ParquetValue::String(v)
-            }
-            ParquetSchemaType::Binary => {
-                let v = convert_to_binary(value)?;
-                ParquetValue::Bytes(v)
-            }
-            ParquetSchemaType::Boolean => {
-                let v = convert_to_boolean(value)?;
-                ParquetValue::Boolean(v)
-            }
-            ParquetSchemaType::Date32 => {
-                let v = convert_to_date32(value, self.format.as_deref())?;
-                ParquetValue::Date32(v)
-            }
-            ParquetSchemaType::TimestampMillis => {
-                let v = convert_to_timestamp_millis(value, self.format.as_deref())?;
-                ParquetValue::TimestampMillis(v, None)
-            }
-            ParquetSchemaType::TimestampMicros => {
-                let v = convert_to_timestamp_micros(value, self.format.as_deref())?;
-                ParquetValue::TimestampMicros(v, None)
-            }
-            ParquetSchemaType::List(list_field) => {
-                let values = convert_to_list(value, list_field)?;
-                ParquetValue::List(values)
-            }
-            ParquetSchemaType::Map(map_field) => {
-                let map = convert_to_map(value, map_field)?;
-                ParquetValue::Map(map)
-            }
-        };
+        // For all other types, proceed as normal
+        let parquet_value = ParquetValue::from_value(value, &self.type_, self.format.as_deref())?;
         self.values.push(parquet_value);
         Ok(())
     }
 
-    pub fn take_array(&mut self) -> Result<Arc<dyn Array>, MagnusError> {
+    pub fn take_array(&mut self) -> Result<Arc<dyn Array>, ReaderError> {
         let values = std::mem::take(&mut self.values);
         crate::convert_parquet_values_to_arrow(values, &self.type_)
     }

--- a/ext/parquet/src/writer/mod.rs
+++ b/ext/parquet/src/writer/mod.rs
@@ -1,16 +1,16 @@
 use std::{
     fs::File,
     io::{self, BufReader, BufWriter},
-    mem,
     sync::Arc,
 };
 
 use arrow_array::{Array, RecordBatch};
-use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use arrow_schema::{DataType, Schema, TimeUnit};
+use itertools::Itertools;
 use magnus::{
     scan_args::{get_kwargs, scan_args},
     value::ReprValue,
-    Error as MagnusError, RArray, Ruby, TryConvert, Value,
+    Error as MagnusError, RArray, RHash, Ruby, Symbol, TryConvert, Value,
 };
 use parquet::{
     arrow::ArrowWriter,
@@ -22,17 +22,209 @@ use tempfile::NamedTempFile;
 
 use crate::{
     convert_ruby_array_to_arrow,
-    types::{ColumnCollector, ParquetErrorWrapper, WriterOutput},
-    IoLikeValue, ParquetSchemaType, ParquetWriteArgs, SchemaField, SendableWrite,
+    logger::RubyLogger,
+    reader::ReaderError,
+    types::{
+        schema_node::build_arrow_schema, // ADDED - we need to reference the DSL's build_arrow_schema
+        ColumnCollector,
+        ParquetSchemaType,
+        WriterOutput,
+    },
+    utils::parse_string_or_symbol,
+    IoLikeValue, ParquetSchemaType as PST, ParquetWriteArgs, SchemaField, SendableWrite,
 };
+use crate::{types::PrimitiveType, SchemaNode}; // ADDED - ensure we import SchemaNode
 
-const MIN_SAMPLES_FOR_ESTIMATE: usize = 10; // Minimum samples needed for estimation
-const SAMPLE_SIZE: usize = 100; // Number of rows to sample for size estimation
-const MIN_BATCH_SIZE: usize = 10; // Minimum batch size to maintain efficiency
-const INITIAL_BATCH_SIZE: usize = 100; // Initial batch size while sampling
-
-// Maximum memory usage per batch (64MB by default)
+const MIN_SAMPLES_FOR_ESTIMATE: usize = 10;
+const SAMPLE_SIZE: usize = 100;
+const MIN_BATCH_SIZE: usize = 10;
+const INITIAL_BATCH_SIZE: usize = 100;
 const DEFAULT_MEMORY_THRESHOLD: usize = 64 * 1024 * 1024;
+
+// -----------------------------------------------------------------------------
+// HELPER to invert arrow DataType back to our ParquetSchemaType
+// Converts Arrow DataType to our internal ParquetSchemaType representation.
+// This is essential for mapping Arrow types back to our schema representation
+// when working with column collections and schema validation.
+// -----------------------------------------------------------------------------
+fn arrow_data_type_to_parquet_schema_type(dt: &DataType) -> Result<ParquetSchemaType, MagnusError> {
+    match dt {
+        DataType::Boolean => Ok(PST::Boolean),
+        DataType::Int8 => Ok(PST::Int8),
+        DataType::Int16 => Ok(PST::Int16),
+        DataType::Int32 => Ok(PST::Int32),
+        DataType::Int64 => Ok(PST::Int64),
+        DataType::UInt8 => Ok(PST::UInt8),
+        DataType::UInt16 => Ok(PST::UInt16),
+        DataType::UInt32 => Ok(PST::UInt32),
+        DataType::UInt64 => Ok(PST::UInt64),
+        DataType::Float16 => {
+            // We do not have a direct ParquetSchemaType::Float16, we treat it as Float
+            Ok(PST::Float)
+        }
+        DataType::Float32 => Ok(PST::Float),
+        DataType::Float64 => Ok(PST::Double),
+        DataType::Date32 => Ok(PST::Date32),
+        DataType::Date64 => {
+            // Our code typically uses Date32 or Timestamp for 64. But Arrow has Date64
+            // We can store it as PST::Date64 if we want. If we don't have that, consider PST::Date32 or an error.
+            // If your existing code only handles Date32, you can error. But let's do PST::Date32 as fallback:
+            // Or define a new variant if you have one in your code. We'll show a fallback approach:
+            Err(MagnusError::new(
+                magnus::exception::runtime_error(),
+                "Arrow Date64 not directly supported in current ParquetSchemaType (use date32?).",
+            ))
+        }
+        DataType::Timestamp(TimeUnit::Second, _tz) => {
+            // We'll treat this as PST::TimestampMillis, or define PST::TimestampSecond
+            // For simplicity, let's map "second" to PST::TimestampMillis with a note:
+            Ok(PST::TimestampMillis)
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, _tz) => Ok(PST::TimestampMillis),
+        DataType::Timestamp(TimeUnit::Microsecond, _tz) => Ok(PST::TimestampMicros),
+        DataType::Timestamp(TimeUnit::Nanosecond, _tz) => {
+            // If you have a PST::TimestampNanos variant, use it. Otherwise, degrade to micros
+            // for demonstration:
+            Err(MagnusError::new(
+                magnus::exception::runtime_error(),
+                "TimestampNanos not supported, please adjust your schema or code.",
+            ))
+        }
+        DataType::Utf8 => Ok(PST::String),
+        DataType::Binary => Ok(PST::Binary),
+        DataType::LargeUtf8 => {
+            // If not supported, degrade or error. We'll degrade to PST::String
+            Ok(PST::String)
+        }
+        DataType::LargeBinary => Ok(PST::Binary),
+        DataType::List(child_field) => {
+            // Recursively handle the item type
+            let child_type = arrow_data_type_to_parquet_schema_type(child_field.data_type())?;
+            Ok(PST::List(Box::new(crate::types::ListField {
+                item_type: child_type,
+                format: None,
+                nullable: true,
+            })))
+        }
+        DataType::Map(entry_field, _keys_sorted) => {
+            // Arrow's Map -> a struct<key, value> inside
+            let entry_type = entry_field.data_type();
+            if let DataType::Struct(fields) = entry_type {
+                if fields.len() == 2 {
+                    let key_type = arrow_data_type_to_parquet_schema_type(fields[0].data_type())?;
+                    let value_type = arrow_data_type_to_parquet_schema_type(fields[1].data_type())?;
+                    Ok(PST::Map(Box::new(crate::types::MapField {
+                        key_type,
+                        value_type,
+                        key_format: None,
+                        value_format: None,
+                        value_nullable: true,
+                    })))
+                } else {
+                    Err(MagnusError::new(
+                        magnus::exception::type_error(),
+                        "Map field must have exactly 2 child fields (key, value)",
+                    ))
+                }
+            } else {
+                Err(MagnusError::new(
+                    magnus::exception::type_error(),
+                    "Map field is not a struct? Unexpected Arrow schema layout",
+                ))
+            }
+        }
+        DataType::Struct(arrow_fields) => {
+            // We treat this as PST::Struct. We'll recursively handle subfields
+            // but for top-level collecting we only store them as one column
+            // so the user data must pass a Ruby Hash or something for that field.
+            let mut schema_fields = vec![];
+            for f in arrow_fields {
+                let sub_type = arrow_data_type_to_parquet_schema_type(f.data_type())?;
+                schema_fields.push(SchemaField {
+                    name: f.name().clone(),
+                    type_: sub_type,
+                    format: None, // We can't see the 'format' from Arrow
+                    nullable: f.is_nullable(),
+                });
+            }
+            Ok(PST::Struct(Box::new(crate::types::StructField {
+                fields: schema_fields,
+            })))
+        }
+        _ => Err(MagnusError::new(
+            magnus::exception::runtime_error(),
+            format!("Unsupported or unhandled Arrow DataType: {:?}", dt),
+        )),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// HELPER to build ColumnCollectors for the DSL variant
+// This function converts a SchemaNode (from our DSL) into a collection of ColumnCollectors
+// that can accumulate values for each column in the schema.
+// - arrow_schema: The Arrow schema corresponding to our DSL schema
+// - root_node: The root SchemaNode (expected to be a Struct node) from which to build collectors
+// -----------------------------------------------------------------------------
+fn build_column_collectors_from_dsl<'a>(
+    ruby: &'a Ruby,
+    arrow_schema: &'a Arc<Schema>,
+    root_node: &'a SchemaNode,
+) -> Result<Vec<ColumnCollector<'a>>, MagnusError> {
+    // We expect the top-level schema node to be a Struct so that arrow_schema
+    // lines up with root_node.fields. If the user gave a top-level primitive, it would be 1 field, but
+    // our code calls build_arrow_schema under the assumption "top-level must be Struct."
+    let fields = match root_node {
+        SchemaNode::Struct { fields, .. } => fields,
+        _ => {
+            return Err(MagnusError::new(
+                ruby.exception_runtime_error(),
+                "Top-level schema for DSL must be a struct",
+            ))
+        }
+    };
+
+    if fields.len() != arrow_schema.fields().len() {
+        return Err(MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!(
+                "Mismatch between DSL field count ({}) and Arrow fields ({})",
+                fields.len(),
+                arrow_schema.fields().len()
+            ),
+        ));
+    }
+
+    let mut collectors = Vec::with_capacity(fields.len());
+    for (arrow_field, schema_field_node) in arrow_schema.fields().iter().zip(fields) {
+        let name = arrow_field.name().clone();
+        let parquet_type = arrow_data_type_to_parquet_schema_type(arrow_field.data_type())?;
+
+        // Extract the optional format from the schema node
+        let format = extract_format_from_schema_node(schema_field_node);
+
+        // Build the ColumnCollector
+        collectors.push(ColumnCollector::new(
+            name,
+            parquet_type,
+            format,
+            arrow_field.is_nullable(),
+        ));
+    }
+    Ok(collectors)
+}
+
+// Helper to extract the format from a SchemaNode if available
+fn extract_format_from_schema_node(node: &SchemaNode) -> Option<String> {
+    match node {
+        SchemaNode::Primitive {
+            format: f,
+            parquet_type: _,
+            ..
+        } => f.clone(),
+        // For struct, list, map, etc. there's no single "format." We ignore it.
+        _ => None,
+    }
+}
 
 /// Parse arguments for Parquet writing
 pub fn parse_parquet_write_args(args: &[Value]) -> Result<ParquetWriteArgs, MagnusError> {
@@ -42,12 +234,13 @@ pub fn parse_parquet_write_args(args: &[Value]) -> Result<ParquetWriteArgs, Magn
 
     let kwargs = get_kwargs::<
         _,
-        (Option<RArray>, Value),
+        (Value, Value),
         (
             Option<Option<usize>>,
             Option<Option<usize>>,
             Option<Option<String>>,
             Option<Option<usize>>,
+            Option<Option<Value>>,
         ),
         (),
     >(
@@ -58,146 +251,231 @@ pub fn parse_parquet_write_args(args: &[Value]) -> Result<ParquetWriteArgs, Magn
             "flush_threshold",
             "compression",
             "sample_size",
+            "logger",
         ],
     )?;
 
-    let schema = if kwargs.required.0.is_none() || kwargs.required.0.unwrap().is_empty() {
-        // If schema is nil, we need to peek at the first value to determine column count
-        let first_value = read_from.funcall::<_, _, Value>("peek", ())?;
-        let array = RArray::from_value(first_value).ok_or_else(|| {
-            MagnusError::new(
-                magnus::exception::type_error(),
-                "First value must be an array when schema is not provided",
-            )
-        })?;
+    // The schema value could be one of:
+    // 1. An array of hashes (legacy format)
+    // 2. A hash with type: :struct (new DSL format)
+    // 3. nil (infer from data)
+    let schema_value = kwargs.required.0;
 
-        // Generate field names f0, f1, f2, etc.
-        (0..array.len())
-            .map(|i| SchemaField {
-                name: format!("f{}", i),
-                type_: ParquetSchemaType::String,
-                format: None,
-            })
-            .collect()
+    // Check if it's the new DSL format (a hash with type: :struct)
+    // We need to handle both direct hash objects and objects created via Parquet::Schema.define
+
+    // First, try to convert it to a Hash if it's not already a Hash
+    // This handles the case where schema_value is a Schema object from Parquet::Schema.define
+    let schema_hash = if schema_value.is_kind_of(ruby.class_hash()) {
+        RHash::from_value(schema_value).ok_or_else(|| {
+            MagnusError::new(magnus::exception::type_error(), "Schema must be a hash")
+        })?
     } else {
-        let schema_array = kwargs.required.0.unwrap();
-
-        let mut schema = Vec::with_capacity(schema_array.len());
-
-        for (idx, field_hash) in schema_array.into_iter().enumerate() {
-            if !field_hash.is_kind_of(ruby.class_hash()) {
-                return Err(MagnusError::new(
-                    magnus::exception::type_error(),
-                    format!("schema[{}] must be a hash", idx),
-                ));
-            }
-
-            let entries: Vec<(Value, Value)> = field_hash.funcall("to_a", ())?;
-            if entries.len() != 1 {
-                return Err(MagnusError::new(
-                    magnus::exception::type_error(),
-                    format!("schema[{}] must contain exactly one key-value pair", idx),
-                ));
-            }
-
-            let (name, type_value) = &entries[0];
-            let name = String::try_convert(name.clone())?;
-
-            let (type_, format) = if type_value.is_kind_of(ruby.class_hash()) {
-                let type_hash: Vec<(Value, Value)> = type_value.funcall("to_a", ())?;
-                let mut type_str = None;
-                let mut format_str = None;
-
-                for (key, value) in type_hash {
-                    let key = String::try_convert(key)?;
-                    match key.as_str() {
-                        "type" => type_str = Some(value),
-                        "format" => format_str = Some(String::try_convert(value)?),
-                        _ => {
-                            return Err(MagnusError::new(
-                                magnus::exception::type_error(),
-                                format!("Unknown key '{}' in type definition", key),
-                            ))
+        // Try to convert the object to a hash with to_h
+        match schema_value.respond_to("to_h", false) {
+            Ok(true) => {
+                match schema_value.funcall::<_, _, Value>("to_h", ()) {
+                    Ok(hash_val) => match RHash::from_value(hash_val) {
+                        Some(hash) => hash,
+                        None => {
+                            // Not a hash, continue to normal handling
+                            RHash::new()
                         }
+                    },
+                    Err(_) => {
+                        // couldn't call to_h, continue to normal handling
+                        RHash::new()
                     }
                 }
+            }
+            _ => {
+                // Doesn't respond to to_h, continue to normal handling
+                RHash::new()
+            }
+        }
+    };
 
-                let type_str = type_str.ok_or_else(|| {
+    // Now check if it's a schema hash with a type: :struct field
+    let type_val = schema_hash.get(Symbol::new("type"));
+
+    if let Some(type_val) = type_val {
+        // If it has a type: :struct, it's the new DSL format
+        // Use parse_string_or_symbol to handle both String and Symbol values
+        let ttype = parse_string_or_symbol(&ruby, type_val)?;
+        if let Some(ref type_str) = ttype {
+            if type_str == "struct" {
+                // Parse using the new schema approach
+                let schema_node = crate::parse_schema_node(&ruby, schema_value)?;
+
+                validate_schema_node(&ruby, &schema_node)?;
+
+                return Ok(ParquetWriteArgs {
+                    read_from,
+                    write_to: kwargs.required.1,
+                    schema: schema_node,
+                    batch_size: kwargs.optional.0.flatten(),
+                    flush_threshold: kwargs.optional.1.flatten(),
+                    compression: kwargs.optional.2.flatten(),
+                    sample_size: kwargs.optional.3.flatten(),
+                    logger: kwargs.optional.4.flatten(),
+                });
+            }
+        }
+    }
+
+    // If it's not a hash with type: :struct, handle as legacy format
+    let schema_fields = if schema_value.is_nil()
+        || (schema_value.is_kind_of(ruby.class_array())
+            && RArray::from_value(schema_value)
+                .ok_or_else(|| {
                     MagnusError::new(
                         magnus::exception::type_error(),
-                        "Missing 'type' in type definition",
+                        "Schema fields must be an array",
                     )
-                })?;
-
-                (ParquetSchemaType::try_convert(type_str)?, format_str)
-            } else {
-                (ParquetSchemaType::try_convert(type_value.clone())?, None)
-            };
-
-            schema.push(SchemaField {
-                name,
-                type_,
-                format,
-            });
-        }
-
-        schema
+                })?
+                .len()
+                == 0)
+    {
+        // If schema is nil or an empty array, we need to peek at the first value to determine column count
+        let first_value = read_from.funcall::<_, _, Value>("peek", ())?;
+        // Default to nullable:true for auto-inferred fields
+        crate::infer_schema_from_first_row(&ruby, first_value, true)?
+    } else {
+        // Legacy array format - use our centralized parser
+        crate::parse_legacy_schema(&ruby, schema_value)?
     };
+
+    // Convert the legacy schema fields to SchemaNode (DSL format)
+    let schema_node = crate::legacy_schema_to_dsl(&ruby, schema_fields)?;
+
+    validate_schema_node(&ruby, &schema_node)?;
 
     Ok(ParquetWriteArgs {
         read_from,
         write_to: kwargs.required.1,
-        schema,
+        schema: schema_node,
         batch_size: kwargs.optional.0.flatten(),
         flush_threshold: kwargs.optional.1.flatten(),
         compression: kwargs.optional.2.flatten(),
         sample_size: kwargs.optional.3.flatten(),
+        logger: kwargs.optional.4.flatten(),
     })
 }
 
-/// Estimate the size of a row
-fn estimate_single_row_size(row: &RArray, schema: &[SchemaField]) -> Result<usize, MagnusError> {
-    let mut row_size = 0;
-    for (field, value) in schema.iter().zip(row.into_iter()) {
-        // Estimate size based on type and value
-        row_size += match &field.type_ {
-            // Use reference to avoid moving
-            ParquetSchemaType::Int8 | ParquetSchemaType::UInt8 => 1,
-            ParquetSchemaType::Int16 | ParquetSchemaType::UInt16 => 2,
-            ParquetSchemaType::Int32
-            | ParquetSchemaType::UInt32
-            | ParquetSchemaType::Float
-            | ParquetSchemaType::Date32 => 4,
-            ParquetSchemaType::Int64
-            | ParquetSchemaType::UInt64
-            | ParquetSchemaType::Double
-            | ParquetSchemaType::TimestampMillis
-            | ParquetSchemaType::TimestampMicros => 8,
-            ParquetSchemaType::String => {
-                if let Ok(s) = String::try_convert(value) {
-                    s.len() + mem::size_of::<usize>() // account for length prefix
-                } else {
-                    16 // default estimate for string
-                }
-            }
-            ParquetSchemaType::Binary => {
-                if let Ok(bytes) = Vec::<u8>::try_convert(value) {
-                    bytes.len() + mem::size_of::<usize>() // account for length prefix
-                } else {
-                    16 // default estimate for binary
-                }
-            }
-            ParquetSchemaType::Boolean => 1,
-            ParquetSchemaType::List(_) | ParquetSchemaType::Map(_) => {
-                32 // rough estimate for complex types
-            }
-        };
+// Validates a SchemaNode to ensure it meets Parquet schema requirements
+// Currently checks for duplicate field names at the root level, which would
+// cause problems when writing Parquet files. Additional validation rules
+// could be added here in the future.
+//
+// This validation is important because schema errors are difficult to debug
+// once they reach the Parquet/Arrow layer, so we check proactively before
+// any data processing begins.
+fn validate_schema_node(ruby: &Ruby, schema_node: &SchemaNode) -> Result<(), MagnusError> {
+    if let SchemaNode::Struct { fields, .. } = &schema_node {
+        // if any root level schema fields have the same name, we raise an error
+        let field_names = fields
+            .iter()
+            .map(|f| match f {
+                SchemaNode::Struct { name, .. } => name.as_str(),
+                SchemaNode::List { name, .. } => name.as_str(),
+                SchemaNode::Map { name, .. } => name.as_str(),
+                SchemaNode::Primitive { name, .. } => name.as_str(),
+            })
+            .collect::<Vec<_>>();
+        let unique_field_names = field_names.iter().unique().collect::<Vec<_>>();
+        if field_names.len() != unique_field_names.len() {
+            return Err(MagnusError::new(
+                ruby.exception_arg_error(),
+                format!(
+                    "Duplicate field names in root level schema: {:?}",
+                    field_names
+                ),
+            ));
+        }
     }
-    Ok(row_size)
+    Ok(())
+}
+
+// Processes a single data row and adds values to the corresponding column collectors
+// This function is called for each row of input data when writing in row-wise mode.
+// It performs important validation to ensure the row structure matches the schema:
+// - Verifies that the number of columns in the row matches the schema
+// - Distributes each value to the appropriate ColumnCollector
+//
+// Each ColumnCollector handles type conversion and accumulation for its specific column,
+// allowing this function to focus on row-level validation and distribution.
+fn process_row(
+    ruby: &Ruby,
+    row: Value,
+    column_collectors: &mut [ColumnCollector],
+) -> Result<(), MagnusError> {
+    let row_array = RArray::from_value(row)
+        .ok_or_else(|| MagnusError::new(ruby.exception_type_error(), "Row must be an array"))?;
+
+    // Validate row length matches schema
+    if row_array.len() != column_collectors.len() {
+        return Err(MagnusError::new(
+            magnus::exception::runtime_error(),
+            format!(
+                "Row length ({}) does not match schema length ({}). Schema expects columns: {:?}",
+                row_array.len(),
+                column_collectors.len(),
+                column_collectors
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+            ),
+        ));
+    }
+
+    // Process each value in the row
+    for (collector, value) in column_collectors.iter_mut().zip(row_array) {
+        collector.push_value(value)?;
+    }
+
+    Ok(())
+}
+
+// Dynamically calculates an optimal batch size based on estimated row sizes
+// and memory constraints. This function enables the writer to adapt to different
+// data characteristics for optimal performance.
+//
+// The algorithm:
+// 1. Requires a minimum number of samples to make a reliable estimate
+// 2. Calculates the average row size from the samples
+// 3. Determines a batch size that would consume approximately the target memory threshold
+// 4. Ensures the batch size doesn't go below a minimum value for efficiency
+//
+// This approach balances memory usage with processing efficiency by targeting
+// a specific memory footprint per batch.
+fn update_batch_size(
+    size_samples: &[usize],
+    flush_threshold: usize,
+    min_batch_size: usize,
+) -> usize {
+    if size_samples.len() < MIN_SAMPLES_FOR_ESTIMATE {
+        return min_batch_size;
+    }
+
+    let total_size = size_samples.iter().sum::<usize>();
+    // Safe because we know we have at least MIN_SAMPLES_FOR_ESTIMATE samples
+    let avg_row_size = total_size as f64 / size_samples.len() as f64;
+    let avg_row_size = avg_row_size.max(1.0); // Ensure we don't divide by zero
+    let suggested_batch_size = (flush_threshold as f64 / avg_row_size).floor() as usize;
+    suggested_batch_size.max(min_batch_size)
 }
 
 #[inline]
 pub fn write_rows(args: &[Value]) -> Result<(), MagnusError> {
+    write_rows_impl(args).map_err(|e| {
+        let z: MagnusError = e.into();
+        z
+    })?;
+    Ok(())
+}
+
+#[inline]
+fn write_rows_impl(args: &[Value]) -> Result<(), ReaderError> {
     let ruby = unsafe { Ruby::get_unchecked() };
 
     let ParquetWriteArgs {
@@ -208,59 +486,27 @@ pub fn write_rows(args: &[Value]) -> Result<(), MagnusError> {
         compression,
         flush_threshold,
         sample_size: user_sample_size,
+        logger,
     } = parse_parquet_write_args(args)?;
 
+    let logger = RubyLogger::new(&ruby, logger)?;
     let flush_threshold = flush_threshold.unwrap_or(DEFAULT_MEMORY_THRESHOLD);
 
-    // Convert schema to Arrow schema
-    let arrow_fields: Vec<Field> = schema
-        .iter()
-        .map(|field| {
-            Field::new(
-                &field.name,
-                match field.type_ {
-                    ParquetSchemaType::Int8 => DataType::Int8,
-                    ParquetSchemaType::Int16 => DataType::Int16,
-                    ParquetSchemaType::Int32 => DataType::Int32,
-                    ParquetSchemaType::Int64 => DataType::Int64,
-                    ParquetSchemaType::UInt8 => DataType::UInt8,
-                    ParquetSchemaType::UInt16 => DataType::UInt16,
-                    ParquetSchemaType::UInt32 => DataType::UInt32,
-                    ParquetSchemaType::UInt64 => DataType::UInt64,
-                    ParquetSchemaType::Float => DataType::Float32,
-                    ParquetSchemaType::Double => DataType::Float64,
-                    ParquetSchemaType::String => DataType::Utf8,
-                    ParquetSchemaType::Binary => DataType::Binary,
-                    ParquetSchemaType::Boolean => DataType::Boolean,
-                    ParquetSchemaType::Date32 => DataType::Date32,
-                    ParquetSchemaType::TimestampMillis => {
-                        DataType::Timestamp(TimeUnit::Millisecond, None)
-                    }
-                    ParquetSchemaType::TimestampMicros => {
-                        DataType::Timestamp(TimeUnit::Microsecond, None)
-                    }
-                    ParquetSchemaType::List(_) => unimplemented!("List type not yet supported"),
-                    ParquetSchemaType::Map(_) => unimplemented!("Map type not yet supported"),
-                },
-                true,
-            )
-        })
-        .collect();
-    let arrow_schema = Arc::new(Schema::new(arrow_fields));
+    // Get the Arrow schema from the SchemaNode (we only have DSL schema now, since legacy is converted)
+    let arrow_schema = build_arrow_schema(&schema, &logger).map_err(|e| {
+        MagnusError::new(
+            magnus::exception::runtime_error(),
+            format!("Failed to build Arrow schema from DSL schema: {}", e),
+        )
+    })?;
 
     // Create the writer
     let mut writer = create_writer(&ruby, &write_to, arrow_schema.clone(), compression)?;
 
     if read_from.is_kind_of(ruby.class_enumerator()) {
-        // Create collectors for each column
-        let mut column_collectors: Vec<ColumnCollector> = schema
-            .iter()
-            .map(|field| {
-                // Clone the type to avoid moving from a reference
-                let type_clone = field.type_.clone();
-                ColumnCollector::new(field.name.clone(), type_clone, field.format.clone())
-            })
-            .collect();
+        // Build column collectors - we only have DSL schema now
+        let mut column_collectors =
+            build_column_collectors_from_dsl(&ruby, &arrow_schema, &schema)?;
 
         let mut rows_in_batch = 0;
         let mut total_rows = 0;
@@ -272,48 +518,33 @@ pub fn write_rows(args: &[Value]) -> Result<(), MagnusError> {
         loop {
             match read_from.funcall::<_, _, Value>("next", ()) {
                 Ok(row) => {
-                    let row_array = RArray::from_value(row).ok_or_else(|| {
-                        MagnusError::new(ruby.exception_type_error(), "Row must be an array")
-                    })?;
+                    // Process the row
+                    process_row(&ruby, row, &mut column_collectors)?;
 
-                    // Validate row length matches schema
-                    if row_array.len() != column_collectors.len() {
-                        return Err(MagnusError::new(
-                            magnus::exception::type_error(),
-                            format!(
-                                "Row length ({}) does not match schema length ({}). Schema expects columns: {:?}",
-                                row_array.len(),
-                                column_collectors.len(),
-                                column_collectors.iter().map(|c| c.name.as_str()).collect::<Vec<_>>()
-                            ),
-                        ));
-                    }
-
-                    // Sample row sizes using reservoir sampling
+                    // Update row sampling for dynamic batch sizing
                     if size_samples.len() < sample_size {
-                        size_samples.push(estimate_single_row_size(&row_array, &schema)?);
-                    } else if rng.random_range(0..=total_rows) < sample_size {
-                        let idx = rng.random_range(0..sample_size);
-                        size_samples[idx] = estimate_single_row_size(&row_array, &schema)?;
-                    }
-
-                    // Process each value in the row
-                    for (collector, value) in column_collectors.iter_mut().zip(row_array) {
-                        collector.push_value(value)?;
+                        // estimate row size
+                        let row_array = RArray::from_value(row).ok_or_else(|| {
+                            MagnusError::new(ruby.exception_type_error(), "Row must be an array")
+                        })?;
+                        let row_size = estimate_single_row_size(&row_array, &column_collectors)?;
+                        size_samples.push(row_size);
+                    } else if rng.random_range(0..=total_rows) < sample_size as usize {
+                        let idx = rng.random_range(0..sample_size as usize);
+                        let row_array = RArray::from_value(row).ok_or_else(|| {
+                            MagnusError::new(ruby.exception_type_error(), "Row must be an array")
+                        })?;
+                        let row_size = estimate_single_row_size(&row_array, &column_collectors)?;
+                        size_samples[idx] = row_size;
                     }
 
                     rows_in_batch += 1;
                     total_rows += 1;
 
                     // Calculate batch size progressively once we have minimum samples
-                    if size_samples.len() >= MIN_SAMPLES_FOR_ESTIMATE && user_batch_size.is_none() {
-                        let total_size = size_samples.iter().sum::<usize>();
-                        // Safe because we know we have at least MIN_SAMPLES_FOR_ESTIMATE samples
-                        let avg_row_size = total_size as f64 / size_samples.len() as f64;
-                        let avg_row_size = avg_row_size.max(1.0); // Ensure we don't divide by zero
-                        let suggested_batch_size =
-                            (flush_threshold as f64 / avg_row_size).floor() as usize;
-                        current_batch_size = suggested_batch_size.max(MIN_BATCH_SIZE);
+                    if user_batch_size.is_none() && size_samples.len() >= MIN_SAMPLES_FOR_ESTIMATE {
+                        current_batch_size =
+                            update_batch_size(&size_samples, flush_threshold, MIN_BATCH_SIZE);
                     }
 
                     // When we reach batch size, write the batch
@@ -330,19 +561,19 @@ pub fn write_rows(args: &[Value]) -> Result<(), MagnusError> {
                         }
                         break;
                     }
-                    return Err(e);
+                    return Err(e)?;
                 }
             }
         }
     } else {
         return Err(MagnusError::new(
             magnus::exception::type_error(),
-            "read_from must be an Enumerator",
-        ));
+            "read_from must be an Enumerator".to_string(),
+        ))?;
     }
 
     // Ensure everything is written and get the temp file if it exists
-    if let Some(temp_file) = writer.close().map_err(|e| ParquetErrorWrapper(e))? {
+    if let Some(temp_file) = writer.close()? {
         // If we got a temp file back, we need to copy its contents to the IO-like object
         copy_temp_file_to_io_like(temp_file, IoLikeValue(write_to))?;
     }
@@ -352,6 +583,15 @@ pub fn write_rows(args: &[Value]) -> Result<(), MagnusError> {
 
 #[inline]
 pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
+    write_columns_impl(args).map_err(|e| {
+        let z: MagnusError = e.into();
+        z
+    })?;
+    Ok(())
+}
+
+#[inline]
+fn write_columns_impl(args: &[Value]) -> Result<(), ReaderError> {
     let ruby = unsafe { Ruby::get_unchecked() };
 
     let ParquetWriteArgs {
@@ -362,45 +602,19 @@ pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
         compression,
         flush_threshold,
         sample_size: _,
+        logger,
     } = parse_parquet_write_args(args)?;
 
+    let logger = RubyLogger::new(&ruby, logger)?;
     let flush_threshold = flush_threshold.unwrap_or(DEFAULT_MEMORY_THRESHOLD);
 
-    // Convert schema to Arrow schema
-    let arrow_fields: Vec<Field> = schema
-        .iter()
-        .map(|field| {
-            Field::new(
-                &field.name,
-                match field.type_ {
-                    ParquetSchemaType::Int8 => DataType::Int8,
-                    ParquetSchemaType::Int16 => DataType::Int16,
-                    ParquetSchemaType::Int32 => DataType::Int32,
-                    ParquetSchemaType::Int64 => DataType::Int64,
-                    ParquetSchemaType::UInt8 => DataType::UInt8,
-                    ParquetSchemaType::UInt16 => DataType::UInt16,
-                    ParquetSchemaType::UInt32 => DataType::UInt32,
-                    ParquetSchemaType::UInt64 => DataType::UInt64,
-                    ParquetSchemaType::Float => DataType::Float32,
-                    ParquetSchemaType::Double => DataType::Float64,
-                    ParquetSchemaType::String => DataType::Utf8,
-                    ParquetSchemaType::Binary => DataType::Binary,
-                    ParquetSchemaType::Boolean => DataType::Boolean,
-                    ParquetSchemaType::Date32 => DataType::Date32,
-                    ParquetSchemaType::TimestampMillis => {
-                        DataType::Timestamp(TimeUnit::Millisecond, None)
-                    }
-                    ParquetSchemaType::TimestampMicros => {
-                        DataType::Timestamp(TimeUnit::Microsecond, None)
-                    }
-                    ParquetSchemaType::List(_) => unimplemented!("List type not yet supported"),
-                    ParquetSchemaType::Map(_) => unimplemented!("Map type not yet supported"),
-                },
-                true,
-            )
-        })
-        .collect();
-    let arrow_schema = Arc::new(Schema::new(arrow_fields));
+    // Get the Arrow schema from the SchemaNode (we only have DSL schema now, since legacy is converted)
+    let arrow_schema = build_arrow_schema(&schema, &logger).map_err(|e| {
+        MagnusError::new(
+            magnus::exception::runtime_error(),
+            format!("Failed to build Arrow schema from DSL schema: {}", e),
+        )
+    })?;
 
     // Create the writer
     let mut writer = create_writer(&ruby, &write_to, arrow_schema.clone(), compression)?;
@@ -422,36 +636,111 @@ pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
                     })?;
 
                     // Validate batch length matches schema
-                    if batch_array.len() != schema.len() {
+                    // Get schema length and field names - we only have DSL schema now
+                    let (schema_len, field_names): (usize, Vec<&str>) = {
+                        let fields = match &schema {
+                            SchemaNode::Struct { fields, .. } => fields,
+                            _ => {
+                                return Err(MagnusError::new(
+                                    magnus::exception::type_error(),
+                                    "Root schema node must be a struct type",
+                                ))?
+                            }
+                        };
+                        (
+                            fields.len(),
+                            fields
+                                .iter()
+                                .map(|f| match f {
+                                    SchemaNode::Primitive { name, .. } => name.as_str(),
+                                    SchemaNode::List { name, .. } => name.as_str(),
+                                    SchemaNode::Map { name, .. } => name.as_str(),
+                                    SchemaNode::Struct { name, .. } => name.as_str(),
+                                })
+                                .to_owned()
+                                .collect(),
+                        )
+                    };
+
+                    if batch_array.len() != schema_len {
                         return Err(MagnusError::new(
                             magnus::exception::type_error(),
                             format!(
                                 "Batch column count ({}) does not match schema length ({}). Schema expects columns: {:?}",
                                 batch_array.len(),
-                                schema.len(),
-                                schema.iter().map(|f| f.name.as_str()).collect::<Vec<_>>()
+                                schema_len,
+                                field_names
                             ),
-                        ));
+                        ))?;
                     }
 
                     // Convert each column in the batch to Arrow arrays
-                    let arrow_arrays: Vec<(String, Arc<dyn Array>)> = schema
-                        .iter()
-                        .zip(batch_array)
-                        .map(|(field, column)| {
-                            let column_array = RArray::from_value(column).ok_or_else(|| {
+                    let arrow_arrays: Vec<(String, Arc<dyn Array>)> = {
+                        // Process each field in the DSL schema
+                        let fields = arrow_schema.fields();
+                        let top_fields =
+                            match &schema {
+                                SchemaNode::Struct { fields, .. } => fields,
+                                _ => return Err(MagnusError::new(
+                                    magnus::exception::runtime_error(),
+                                    "Top-level DSL schema must be a struct for columns approach",
+                                ))?,
+                            };
+                        if top_fields.len() != fields.len() {
+                            return Err(MagnusError::new(
+                                magnus::exception::runtime_error(),
+                                "Mismatch top-level DSL fields vs Arrow fields",
+                            ))?;
+                        }
+
+                        let mut out = vec![];
+                        for ((arrow_f, dsl_f), col_val) in
+                            fields.iter().zip(top_fields.iter()).zip(batch_array)
+                        {
+                            let col_arr = RArray::from_value(col_val).ok_or_else(|| {
                                 MagnusError::new(
                                     magnus::exception::type_error(),
-                                    format!("Column '{}' must be an array", field.name),
+                                    format!("Column '{}' must be an array", arrow_f.name()),
                                 )
                             })?;
-
-                            Ok((
-                                field.name.clone(),
-                                convert_ruby_array_to_arrow(column_array, &field.type_)?,
-                            ))
-                        })
-                        .collect::<Result<_, MagnusError>>()?;
+                            // Get appropriate parquet_type
+                            let ptype = match dsl_f {
+                                SchemaNode::Primitive {
+                                    parquet_type,
+                                    // Format is handled internally now
+                                    ..
+                                } => match parquet_type {
+                                    &PrimitiveType::Int8 => PST::Int8,
+                                    &PrimitiveType::Int16 => PST::Int16,
+                                    &PrimitiveType::Int32 => PST::Int32,
+                                    &PrimitiveType::Int64 => PST::Int64,
+                                    &PrimitiveType::UInt8 => PST::UInt8,
+                                    &PrimitiveType::UInt16 => PST::UInt16,
+                                    &PrimitiveType::UInt32 => PST::UInt32,
+                                    &PrimitiveType::UInt64 => PST::UInt64,
+                                    &PrimitiveType::Float32 => PST::Float,
+                                    &PrimitiveType::Float64 => PST::Double,
+                                    &PrimitiveType::String => PST::String,
+                                    &PrimitiveType::Binary => PST::Binary,
+                                    &PrimitiveType::Boolean => PST::Boolean,
+                                    &PrimitiveType::Date32 => PST::Date32,
+                                    &PrimitiveType::TimestampMillis => PST::TimestampMillis,
+                                    &PrimitiveType::TimestampMicros => PST::TimestampMicros,
+                                },
+                                SchemaNode::List { .. }
+                                | SchemaNode::Map { .. }
+                                | SchemaNode::Struct { .. } => {
+                                    // For nested, we just do a single "column" as well
+                                    arrow_data_type_to_parquet_schema_type(arrow_f.data_type())?
+                                }
+                            };
+                            out.push((
+                                arrow_f.name().clone(),
+                                convert_ruby_array_to_arrow(col_arr, &ptype)?,
+                            ));
+                        }
+                        out
+                    };
 
                     // Create and write record batch
                     let record_batch = RecordBatch::try_from_iter(arrow_arrays).map_err(|e| {
@@ -461,14 +750,12 @@ pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
                         )
                     })?;
 
-                    writer
-                        .write(&record_batch)
-                        .map_err(|e| ParquetErrorWrapper(e))?;
+                    writer.write(&record_batch)?;
 
                     match &mut writer {
                         WriterOutput::File(w) | WriterOutput::TempFile(w, _) => {
                             if w.in_progress_size() >= flush_threshold {
-                                w.flush().map_err(|e| ParquetErrorWrapper(e))?;
+                                w.flush()?;
                             }
                         }
                     }
@@ -477,19 +764,19 @@ pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
                     if e.is_kind_of(ruby.exception_stop_iteration()) {
                         break;
                     }
-                    return Err(e);
+                    return Err(e)?;
                 }
             }
         }
     } else {
         return Err(MagnusError::new(
             magnus::exception::type_error(),
-            "read_from must be an Enumerator",
-        ));
+            "read_from must be an Enumerator".to_string(),
+        ))?;
     }
 
     // Ensure everything is written and get the temp file if it exists
-    if let Some(temp_file) = writer.close().map_err(|e| ParquetErrorWrapper(e))? {
+    if let Some(temp_file) = writer.close()? {
         // If we got a temp file back, we need to copy its contents to the IO-like object
         copy_temp_file_to_io_like(temp_file, IoLikeValue(write_to))?;
     }
@@ -497,12 +784,23 @@ pub fn write_columns(args: &[Value]) -> Result<(), MagnusError> {
     Ok(())
 }
 
+// Creates an appropriate Parquet writer based on the output target and compression settings
+// This function handles two main output scenarios:
+// 1. Writing directly to a file path (string)
+// 2. Writing to a Ruby IO-like object (using a temporary file as an intermediate buffer)
+//
+// For IO-like objects, the function creates a temporary file that is later copied to the
+// IO object when writing is complete. This approach is necessary because Parquet requires
+// random file access to write its footer after the data.
+//
+// The function also configures compression based on the user's preferences, with
+// several options available (none, snappy, gzip, lz4, zstd).
 fn create_writer(
     ruby: &Ruby,
     write_to: &Value,
     schema: Arc<Schema>,
     compression: Option<String>,
-) -> Result<WriterOutput, MagnusError> {
+) -> Result<WriterOutput, ReaderError> {
     // Create writer properties with compression based on the option
     let props = WriterProperties::builder()
         .set_compression(match compression.as_deref() {
@@ -517,9 +815,8 @@ fn create_writer(
 
     if write_to.is_kind_of(ruby.class_string()) {
         let path = write_to.to_r_string()?.to_string()?;
-        let file: Box<dyn SendableWrite> = Box::new(File::create(path).unwrap());
-        let writer =
-            ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| ParquetErrorWrapper(e))?;
+        let file: Box<dyn SendableWrite> = Box::new(File::create(path)?);
+        let writer = ArrowWriter::try_new(file, schema, Some(props))?;
         Ok(WriterOutput::File(writer))
     } else {
         // Create a temporary file to write to instead of directly to the IoLikeValue
@@ -535,13 +832,22 @@ fn create_writer(
                 format!("Failed to reopen temporary file: {}", e),
             )
         })?);
-        let writer =
-            ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| ParquetErrorWrapper(e))?;
+        let writer = ArrowWriter::try_new(file, schema, Some(props))?;
         Ok(WriterOutput::TempFile(writer, temp_file))
     }
 }
 
-// Helper function to copy temp file contents to IoLikeValue
+// Copies the contents of a temporary file to a Ruby IO-like object
+// This function is necessary because Parquet writing requires random file access
+// (especially for writing the footer after all data), but Ruby IO objects may not
+// support seeking. The solution is to:
+//
+// 1. Write the entire Parquet file to a temporary file first
+// 2. Once writing is complete, copy the entire contents to the Ruby IO object
+//
+// This approach enables support for a wide range of Ruby IO objects like StringIO,
+// network streams, etc., but does require enough disk space for the temporary file
+// and involves a second full-file read/write operation at the end.
 fn copy_temp_file_to_io_like(
     temp_file: NamedTempFile,
     io_like: IoLikeValue,
@@ -565,36 +871,278 @@ fn copy_temp_file_to_io_like(
     Ok(())
 }
 
+// Estimates the memory size of a single row by examining each value
+// This is used for dynamic batch sizing to optimize memory usage during writes
+// by adapting batch sizes based on the actual data being processed.
+pub fn estimate_single_row_size(
+    row_array: &RArray,
+    collectors: &[ColumnCollector],
+) -> Result<usize, MagnusError> {
+    let mut size = 0;
+    for (idx, val) in row_array.into_iter().enumerate() {
+        let col_type = &collectors[idx].type_;
+        // Calculate size based on the type-specific estimation
+        size += estimate_value_size(val, col_type)?;
+    }
+    Ok(size)
+}
+
+// Estimates the memory footprint of a single value based on its schema type
+// This provides type-specific size estimates that help with dynamic batch sizing
+// For complex types like lists, maps, and structs, we use reasonable approximations
+pub fn estimate_value_size(
+    value: Value,
+    schema_type: &ParquetSchemaType,
+) -> Result<usize, MagnusError> {
+    use ParquetSchemaType as PST;
+    if value.is_nil() {
+        return Ok(0); // nil => minimal
+    }
+    match schema_type {
+        PST::Int8 | PST::UInt8 => Ok(1),
+        PST::Int16 | PST::UInt16 => Ok(2),
+        PST::Int32 | PST::UInt32 | PST::Float => Ok(4),
+        PST::Int64 | PST::UInt64 | PST::Double => Ok(8),
+        PST::Boolean => Ok(1),
+        PST::Date32 | PST::TimestampMillis | PST::TimestampMicros => Ok(8),
+        PST::String | PST::Binary => {
+            if let Ok(s) = String::try_convert(value) {
+                // Account for string length plus Rust String's capacity+pointer overhead
+                Ok(s.len() + std::mem::size_of::<usize>() * 3)
+            } else {
+                // Try to convert the value to a string using to_s for non-string types
+                // This handles numeric values that will be converted to strings later
+                let _ruby = unsafe { Ruby::get_unchecked() };
+                match value.funcall::<_, _, Value>("to_s", ()) {
+                    Ok(str_val) => {
+                        if let Ok(s) = String::try_convert(str_val) {
+                            Ok(s.len() + std::mem::size_of::<usize>() * 3)
+                        } else {
+                            // If to_s conversion fails, just use a reasonable default
+                            Ok(8) // Reasonable size estimate for small values
+                        }
+                    }
+                    Err(_) => {
+                        // If to_s method fails, use a default size
+                        Ok(8) // Reasonable size estimate for small values
+                    }
+                }
+            }
+        }
+        PST::List(item_type) => {
+            if let Ok(arr) = RArray::try_convert(value) {
+                let len = arr.len();
+
+                // Base overhead for the array structure (pointer, length, capacity)
+                let base_size = std::mem::size_of::<usize>() * 3;
+
+                // If empty, just return the base size
+                if len == 0 {
+                    return Ok(base_size);
+                }
+
+                // Sample up to 5 elements to get average element size
+                let sample_count = std::cmp::min(len, 5);
+                let mut total_sample_size = 0;
+
+                for i in 0..sample_count {
+                    let element = arr.entry(i as isize)?;
+                    let element_size = estimate_value_size(element, &item_type.item_type)?;
+                    total_sample_size += element_size;
+                }
+
+                // If we couldn't sample any elements properly, that's an error
+                if sample_count > 0 && total_sample_size == 0 {
+                    return Err(MagnusError::new(
+                        magnus::exception::runtime_error(),
+                        "Failed to estimate size of list elements",
+                    ));
+                }
+
+                // Calculate average element size from samples
+                let avg_element_size = if sample_count > 0 {
+                    total_sample_size as f64 / sample_count as f64
+                } else {
+                    return Err(MagnusError::new(
+                        magnus::exception::runtime_error(),
+                        "Failed to sample list elements for size estimation",
+                    ));
+                };
+
+                // Estimate total size based on average element size * length + base overhead
+                Ok(base_size + (avg_element_size as usize * len))
+            } else {
+                // Instead of assuming it's a small list, return an error
+                Err(MagnusError::new(
+                    magnus::exception::runtime_error(),
+                    format!("Expected array for List type but got: {:?}", value),
+                ))
+            }
+        }
+        PST::Map(map_field) => {
+            if let Ok(hash) = RHash::try_convert(value) {
+                let size_estimate = hash.funcall::<_, _, usize>("size", ())?;
+
+                // Base overhead for the hash structure
+                let base_size = std::mem::size_of::<usize>() * 4;
+
+                // If empty, just return the base size
+                if size_estimate == 0 {
+                    return Ok(base_size);
+                }
+
+                // Sample up to 5 key-value pairs to estimate average sizes
+                let mut key_sample_size = 0;
+                let mut value_sample_size = 0;
+                let mut sample_count = 0;
+
+                // Get an enumerator for the hash
+                let enumerator = hash.funcall::<_, _, Value>("to_enum", ())?;
+
+                // Sample up to 5 entries
+                for _ in 0..std::cmp::min(size_estimate, 5) {
+                    match enumerator.funcall::<_, _, Value>("next", ()) {
+                        Ok(pair) => {
+                            if let Ok(pair_array) = RArray::try_convert(pair) {
+                                if pair_array.len() == 2 {
+                                    let key = pair_array.entry(0)?;
+                                    let val = pair_array.entry(1)?;
+
+                                    key_sample_size +=
+                                        estimate_value_size(key, &map_field.key_type)?;
+                                    value_sample_size +=
+                                        estimate_value_size(val, &map_field.value_type)?;
+                                    sample_count += 1;
+                                }
+                            }
+                        }
+                        Err(_) => break, // Stop if we reach the end
+                    }
+                }
+
+                // If we couldn't sample any pairs, return an error
+                if size_estimate > 0 && sample_count == 0 {
+                    return Err(MagnusError::new(
+                        magnus::exception::runtime_error(),
+                        "Failed to sample map entries for size estimation",
+                    ));
+                }
+
+                // Calculate average key and value sizes
+                let (avg_key_size, avg_value_size) = if sample_count > 0 {
+                    (
+                        key_sample_size as f64 / sample_count as f64,
+                        value_sample_size as f64 / sample_count as f64,
+                    )
+                } else {
+                    return Err(MagnusError::new(
+                        magnus::exception::runtime_error(),
+                        "Failed to sample hash key-value pairs for size estimation",
+                    ));
+                };
+
+                // Each entry has overhead (node pointers, etc.) in a hash map
+                let entry_overhead = std::mem::size_of::<usize>() * 2;
+
+                // Estimate total size:
+                // base size + (key_size + value_size + entry_overhead) * count
+                Ok(base_size
+                    + ((avg_key_size + avg_value_size + entry_overhead as f64) as usize
+                        * size_estimate))
+            } else {
+                // Instead of assuming a small map, return an error
+                Err(MagnusError::new(
+                    magnus::exception::runtime_error(),
+                    format!("Expected hash for Map type but got: {:?}", value),
+                ))
+            }
+        }
+        PST::Struct(struct_field) => {
+            if let Ok(hash) = RHash::try_convert(value) {
+                // Base overhead for the struct
+                let base_size = std::mem::size_of::<usize>() * 3;
+
+                // Estimate size for each field
+                let mut total_fields_size = 0;
+
+                for field in &struct_field.fields {
+                    // Try to get the field value from the hash
+                    match hash.get(Symbol::new(&field.name)) {
+                        Some(field_value) => {
+                            total_fields_size += estimate_value_size(field_value, &field.type_)?;
+                        }
+                        None => {
+                            if let Some(field_value) = hash.get(&*field.name) {
+                                total_fields_size +=
+                                    estimate_value_size(field_value, &field.type_)?;
+                            } else {
+                                if field.nullable {
+                                    total_fields_size += 0;
+                                } else {
+                                    return Err(MagnusError::new(
+                                        magnus::exception::runtime_error(),
+                                        format!("Missing field: {} in hash {:?}", field.name, hash),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // We no longer error on missing fields during size estimation
+                Ok(base_size + total_fields_size)
+            } else {
+                // Instead of trying instance_variables or assuming a default, return an error
+                Err(MagnusError::new(
+                    magnus::exception::runtime_error(),
+                    format!("Expected hash for Struct type but got: {:?}", value),
+                ))
+            }
+        }
+    }
+}
+
+// Converts all accumulated data from ColumnCollectors into an Arrow RecordBatch
+// and writes it to the Parquet file/output. This is a crucial function that bridges
+// between our Ruby-oriented data collectors and the Arrow/Parquet ecosystem.
+//
+// The function:
+// 1. Takes all collected values from each ColumnCollector and converts them to Arrow arrays
+// 2. Creates a RecordBatch from these arrays (column-oriented data format)
+// 3. Writes the batch to the ParquetWriter
+// 4. Flushes the writer if the accumulated memory exceeds the threshold
+//
+// This approach enables efficient batch-wise writing while controlling memory usage.
 fn write_batch(
     writer: &mut WriterOutput,
     collectors: &mut [ColumnCollector],
     flush_threshold: usize,
-) -> Result<(), MagnusError> {
+) -> Result<(), ReaderError> {
     // Convert columns to Arrow arrays
     let arrow_arrays: Vec<(String, Arc<dyn Array>)> = collectors
         .iter_mut()
-        .map(|collector| Ok((collector.name.clone(), collector.take_array()?)))
-        .collect::<Result<_, MagnusError>>()?;
+        .map(|c| {
+            let arr = c.take_array()?;
+            Ok((c.name.clone(), arr))
+        })
+        .collect::<Result<_, ReaderError>>()?;
 
-    // Create and write record batch
-    let record_batch = RecordBatch::try_from_iter(arrow_arrays).map_err(|e| {
+    let record_batch = RecordBatch::try_from_iter(arrow_arrays.clone()).map_err(|e| {
         MagnusError::new(
             magnus::exception::runtime_error(),
-            format!("Failed to create record batch: {}", e),
+            format!("Failed to create RecordBatch: {}", e),
         )
     })?;
 
-    writer
-        .write(&record_batch)
-        .map_err(|e| ParquetErrorWrapper(e))?;
+    writer.write(&record_batch)?;
 
+    // Check if we need to flush based on memory usage thresholds
     match writer {
         WriterOutput::File(w) | WriterOutput::TempFile(w, _) => {
             if w.in_progress_size() >= flush_threshold || w.memory_size() >= flush_threshold {
-                w.flush().map_err(|e| ParquetErrorWrapper(e))?;
+                w.flush()?;
             }
         }
     }
-
     Ok(())
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,14 +38,28 @@
       url = "github:ipetkov/crane";
     };
   };
-  outputs = inputs:
+  outputs =
+    inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
       imports = [
 
       ];
 
-      perSystem = { config, self', inputs', pkgs, system, ... }:
+      perSystem =
+        {
+          config,
+          self',
+          inputs',
+          pkgs,
+          system,
+          ...
+        }:
         let
           linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
         in
@@ -75,12 +89,14 @@
           };
           legacyPackages.nixpkgs = pkgs;
           devShells.default = pkgs.mkShell {
-            packages = with pkgs;[
+            packages = with pkgs; [
               ruby_3_3
               duckdb
               bundler
               rust-analyzer-unwrapped
               rust-dev-toolchain
+              jemalloc
+              pkg-config
             ];
           };
         };

--- a/lib/parquet.rb
+++ b/lib/parquet.rb
@@ -1,4 +1,5 @@
 require_relative "parquet/version"
+require_relative "parquet/schema"
 
 begin
   require "parquet/#{RUBY_VERSION.to_f}/parquet"

--- a/lib/parquet/schema.rb
+++ b/lib/parquet/schema.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Parquet
+  # Schema definition for Parquet files
+  class Schema
+    # Define a new schema using the DSL
+    # @return [Hash] schema definition hash
+    #
+    # @example Define a schema with nullable and non-nullable fields
+    #   Parquet::Schema.define do
+    #     field :id, :int64, nullable: false  # ID cannot be null
+    #     field :name, :string  # Default nullable: true
+    #
+    #     # List with non-nullable items
+    #     field :scores, :list, item: :float, item_nullable: false
+    #
+    #     # Map with nullable values
+    #     field :metadata, :map,
+    #           key: :string,
+    #           value: :string,
+    #           value_nullable: true
+    #
+    #     # Nested struct with non-nullable fields
+    #     field :address, :struct, nullable: true do
+    #       field :street, :string, nullable: false
+    #       field :city, :string, nullable: false
+    #       field :zip, :string, nullable: false
+    #     end
+    #   end
+    def self.define(&block)
+      builder = SchemaBuilder.new
+      builder.instance_eval(&block)
+
+      # Return a structured hash representing the schema
+      { type: :struct, fields: builder.fields }
+    end
+
+    # Internal builder class that provides the DSL methods
+    class SchemaBuilder
+      attr_reader :fields
+
+      def initialize
+        @fields = []
+      end
+
+      # Define a field in the schema
+      # @param name [String, Symbol] field name
+      # @param type [Symbol] data type (:int32, :int64, :string, :list, :map, :struct, etc)
+      # @param nullable [Boolean] whether the field can be null (default: true)
+      # @param kwargs [Hash] additional options depending on type
+      #
+      # Additional keyword args:
+      #   - `item:` if type == :list
+      #   - `item_nullable:` controls nullability of list items (default: true)
+      #   - `key:, value:` if type == :map
+      #   - `key_nullable:, value_nullable:` controls nullability of map keys/values (default: true)
+      #   - `format:` if you want to store some format string
+      #   - `nullable:` default to true if not specified
+      def field(name, type, nullable: true, **kwargs, &block)
+        field_hash = { name: name.to_s, type: type, nullable: !!nullable }
+
+        # Possibly store a format if provided
+        field_hash[:format] = kwargs[:format] if kwargs.key?(:format)
+
+        case type
+        when :struct
+          # We'll parse subfields from the block
+          sub_builder = SchemaBuilder.new
+          sub_builder.instance_eval(&block) if block
+          field_hash[:fields] = sub_builder.fields
+        when :list
+          item_type = kwargs[:item]
+          raise ArgumentError, "list field `#{name}` requires `item:` type" unless item_type
+          # Pass item_nullable if provided, otherwise use true as default
+          item_nullable = kwargs[:item_nullable].nil? ? true : !!kwargs[:item_nullable]
+          field_hash[:item] = wrap_subtype(item_type, nullable: item_nullable, &block)
+        when :map
+          # user must specify key:, value:
+          key_type = kwargs[:key]
+          value_type = kwargs[:value]
+          raise ArgumentError, "map field `#{name}` requires `key:` and `value:`" if key_type.nil? || value_type.nil?
+          # Pass key_nullable and value_nullable if provided, otherwise use true as default
+          key_nullable = kwargs[:key_nullable].nil? ? true : !!kwargs[:key_nullable]
+          value_nullable = kwargs[:value_nullable].nil? ? true : !!kwargs[:value_nullable]
+          field_hash[:key] = wrap_subtype(key_type, nullable: key_nullable)
+          field_hash[:value] = wrap_subtype(value_type, nullable: value_nullable, &block)
+        else
+          # primitive type: :int32, :int64, :string, etc.
+          # do nothing else special
+        end
+
+        @fields << field_hash
+      end
+
+      def build_map(key_type, value_type, key_nullable: false, value_nullable: true, nullable: true, &block)
+        # Wrap the key type (maps typically use non-nullable keys)
+        key = wrap_subtype(key_type, nullable: key_nullable)
+
+        # Handle the case where value_type is a complex type (:struct or :list) and a block is provided
+        value =
+          if (value_type == :struct || value_type == :list) && block
+            wrap_subtype(value_type, nullable: value_nullable, &block)
+          else
+            wrap_subtype(value_type, nullable: value_nullable)
+          end
+
+        # Map is represented as a list of key/value pairs in Parquet
+        {
+          type: :map,
+          nullable: nullable,
+          item: {
+            type: :struct,
+            nullable: false,
+            name: "key_value",
+            fields: [key, value]
+          }
+        }
+      end
+
+      private
+
+      # If user said: field "something", :list, item: :struct do ... end
+      # we want to recursively parse that sub-struct from the block.
+      # So wrap_subtype might be:
+      def wrap_subtype(t, nullable: true, &block)
+        if t == :struct
+          sub_builder = SchemaBuilder.new
+          sub_builder.instance_eval(&block) if block
+
+          # Validate that the struct has at least one field
+          if sub_builder.fields.empty?
+            raise ArgumentError, "Cannot create a struct with zero fields. Parquet doesn't support empty structs."
+          end
+
+          { type: :struct, nullable: nullable, name: "item", fields: sub_builder.fields }
+        elsif t == :list && block
+          # Handle nested lists by processing the block to define the item type
+          sub_builder = SchemaBuilder.new
+          sub_builder.instance_eval(&block) if block
+
+          # We expect a single field named "item" that defines the inner list's item type
+          if sub_builder.fields.empty? || sub_builder.fields.length > 1 || sub_builder.fields[0][:name] != "item"
+            raise ArgumentError, "Nested list must define exactly one field named 'item' for the inner list's item type"
+          end
+
+          { type: :list, nullable: nullable, name: "item", item: sub_builder.fields[0] }
+        else
+          # e.g. :int32 => { type: :int32, nullable: true }
+          { type: t, nullable: nullable, name: "item" }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### New Features & Enhancements

1. **Schema DSL for Complex Data Types**
   - Introduced a **new DSL** (Domain-Specific Language) for defining Parquet schemas in Ruby.
   - You can now describe **structs**, **lists**, and **maps** in a more expressive way:
```ruby
schema = Parquet::Schema.define do
  field :id, :int32, nullable: false
  field :name, :string
  field :age, :int16
  field :weight, :float
  field :active, :boolean
  field :last_seen, :timestamp_millis, nullable: true
  field :scores, :list, item: :int32
  field :details, :struct do
    field :name, :string
    field :score, :double
  end
  field :tags, :list, item: :string
  field :metadata, :map, key: :string, value: :string
  field :properties, :map, key: :string, value: :int32
  field :complex_map, :map, key: :string, value: :struct do
    field :count, :int32
    field :description, :string
  end
  field :nested_lists, :list, item: :list do
    field :item, :string
  end
  field :map_of_lists, :map, key: :string, value: :list do
    field :item, :int32
  end
end
```
   - This DSL supports nested (`struct` within `struct`, `list` of `struct`, etc.) and required/optional fields (`nullable: true`), making it easier to handle complex Parquet schemas.

2. **Writing Maps, Structs, and Lists**
   - The gem now supports **nested data** writes for:
     - **Maps** (`map<keyType, valueType>`), including map of primitives or map of nested types.
     - **Lists** (`list<T>`), including lists of structs or lists of primitives.
     - **Structs** (nested structures), letting you store records that have sub-records.
   - This feature is integrated into both the row-based and column-based writing APIs.
   - Reading these complex types (`each_row`, `each_column`) has been updated as well, so lists and maps yield the expected Ruby arrays and hashes.

3. **Logger Integration**
   - Added support for passing in a **Ruby logger** object for the gem’s internal logging.
   - The gem checks for an optional `logger:` keyword argument in methods and will use it if provided.
   - We'll respect the level returned by `logger.level` otherwise you can also override the log level with the environment variable **`PARQUET_GEM_LOG_LEVEL`** (e.g., `export PARQUET_GEM_LOG_LEVEL=debug`).
   - When no logger is provided, important warnings will print to `stderr`.

4. **Optional Slow Tests in CI**
   - In the GitHub Actions workflow (`ruby.yml`), we now set the environment variable `RUN_SLOW_TESTS=true`.
   - This allows the test suite to include (or skip) certain slow tests. In your local development, you can unset or override this if you want to skip longer-running tests.

### Other Changes

- **Internal Refactoring**:
  - Moved some reading/writing logic into `common.rs` and `logger.rs` for clearer code organization.
  - Introduced a new `RubyLogger` wrapper in Rust for bridging Ruby’s logger with Rust logging methods.
  - Streamlined the enumerator creation code to handle `logger` and `strict` mode more consistently.
  - Improved error-handling wrappers (`MagnusErrorWrapper`) around Rust’s `ParquetError` to raise clearer Ruby exceptions.

### Breaking Changes or Important Notes

- **Non-Null Fields in DSL**: In the new schema DSL, you can mark fields as `nullable: false`. Attempting to write a `nil` value into a non-nullable field will now raise an exception. Previously, the gem did not strictly enforce non-null constraints.
- **Strict UTF-8 Checks**: Writing invalid UTF-8 strings (e.g., corrupted byte sequences) will now raise an `EncodingError` rather than silently truncating or converting them.
- **Complex Nested Fields**: If you attempt to write nested lists/maps/structs but pass incompatible Ruby data (like an array for a map or a simple string instead of a struct-hash), you’ll get a clearer runtime error. The gem enforces that your data matches the declared schema shape.

### Migration Tips

- If you already used the older “legacy” schema format (an array of `{"name" => "type"}` pairs), it will continue to work. However, you can now opt into the **DSL** approach for more nested/complex use cases.
- For better debugging or verbose logs, provide `logger:` in any read/write calls or set `PARQUET_GEM_LOG_LEVEL=debug`.
