### PR TITLE
Add bloom filter support for optimized Parquet querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ schema = [
 Parquet.write_columns(batches.each,
   schema: schema,
   write_to: "output.parquet",
-  compression: "snappy"  # Options: none, snappy, gzip, lz4, zstd
+  compression: "snappy"  # Options: none, snappy, gzip, lz4, zstd, brotli
 )
 ```
 
@@ -364,6 +364,88 @@ schema = Parquet::Schema.define do
 end
 ```
 
+## Bloom Filters
+
+Bloom filters are probabilistic data structures that can significantly speed up queries by allowing readers to skip row groups that definitely don't contain the data they're looking for. They're particularly useful for high-cardinality columns like UUIDs, email addresses, or device IDs.
+
+**Important**: Bloom filters are created **per row group**, not per file. This means each row group (default size: 1M rows) has its own bloom filter for each configured column, allowing fine-grained filtering during queries.
+
+### Basic Usage
+
+```ruby
+# Add bloom filters when writing data
+Parquet.write_rows(data,
+  schema: schema,
+  write_to: "output.parquet",
+  bloom_filters: [
+    { path: ["uuid"], false_positive_probability: 0.01, n_distinct_values: 10_000 },
+    { path: ["email"], false_positive_probability: 0.01, n_distinct_values: 5_000 }
+  ]
+)
+```
+
+### Configuration Options
+
+Each bloom filter configuration supports:
+- `path`: Array of column name parts (required). For top-level columns use a single-element array: `['column_name']`. For nested columns use multiple elements: `['user', 'email']`
+- `false_positive_probability`: Target false positive rate (default: 0.05). Lower values = more accurate but larger filters
+- `n_distinct_values`: Expected number of distinct values (default: 1,000,000). Helps optimize filter size. **Note**: This value is automatically capped to the row group size (default 1M rows) to prevent creating unnecessarily large bloom filters
+
+### Examples
+
+```ruby
+# Using defaults - simplest approach
+bloom_filters: [
+  { path: ["user_id"] }  # Uses default fpp: 0.05, ndv: 1,000,000
+]
+
+# Custom configuration for better accuracy
+bloom_filters: [
+  { path: ["uuid"], false_positive_probability: 0.001, n_distinct_values: 100_000 }
+]
+
+# Multiple columns with different settings
+bloom_filters: [
+  { path: ["user_id"], false_positive_probability: 0.01, n_distinct_values: 50_000 },
+  { path: ["session_id"], false_positive_probability: 0.05, n_distinct_values: 200_000 },
+  { path: ["device_type"] }  # Low cardinality column with defaults
+]
+
+# Nested columns in structured data
+bloom_filters: [
+  { path: ["user", "email"], false_positive_probability: 0.01, n_distinct_values: 10_000 }
+]
+```
+
+### When to Use Bloom Filters
+
+**Good candidates:**
+- High-cardinality columns (UUIDs, email addresses, user IDs)
+- Columns frequently used in WHERE clauses
+- Columns with mostly unique values
+
+**Not recommended for:**
+- Low-cardinality columns (boolean, status codes with few values)
+- Columns rarely used in queries
+- Very small datasets where the overhead isn't worth it
+
+### Trade-offs
+
+- **Storage**: Bloom filters increase file size. A filter for 10,000 values with 0.01 FPP adds ~16KB
+- **Write performance**: Slightly slower writes due to filter computation
+- **Query performance**: Can dramatically improve read performance when filtering data
+
+### Size Estimation
+
+Approximate bloom filter sizes for common configurations:
+
+| Distinct Values | FPP = 0.01 | FPP = 0.05 | FPP = 0.1 |
+|-----------------|------------|------------|-----------|
+| 1,000           | 1.5 KB     | 1 KB       | 0.7 KB    |
+| 10,000          | 16 KB      | 10 KB      | 7 KB      |
+| 100,000         | 150 KB     | 100 KB     | 70 KB     |
+| 1,000,000       | 1.5 MB     | 1 MB       | 700 KB    |
+
 ## Performance Tips
 
 1. **Use column-wise reading** when you need only a few columns from wide tables
@@ -372,6 +454,7 @@ end
    - Larger batches = better throughput but more memory
    - Smaller batches = less memory but more overhead
 4. **Pre-sort data** by commonly filtered columns for better compression
+5. **Add bloom filters** to high-cardinality columns used in WHERE clauses
 
 
 ## Memory Management

--- a/ext/parquet-ruby-adapter/src/types.rs
+++ b/ext/parquet-ruby-adapter/src/types.rs
@@ -15,6 +15,7 @@ pub struct ParquetWriteArgs {
     pub sample_size: Option<usize>,
     pub logger: Option<Value>,
     pub string_cache: Option<bool>,
+    pub bloom_filters: Option<Vec<BloomFilterConfig>>, 
 }
 
 /// Arguments for creating row enumerators
@@ -49,6 +50,14 @@ pub enum WriterOutput {
 pub enum ParserResultType {
     Hash,
     Array,
+}
+
+/// Bloom filter configuration for a single column
+#[derive(Debug, Clone)]
+pub struct BloomFilterConfig {
+    pub path: Vec<String>,
+    pub false_positive_probability: Option<f64>,
+    pub n_distinct_values: Option<u64>,
 }
 
 impl ParserResultType {

--- a/ext/parquet-ruby-adapter/src/utils.rs
+++ b/ext/parquet-ruby-adapter/src/utils.rs
@@ -1,12 +1,12 @@
 use magnus::value::ReprValue;
 use magnus::{
     scan_args::{get_kwargs, scan_args},
-    Error as MagnusError, KwArgs, RArray, RHash, Ruby, Symbol, Value,
+    Error as MagnusError, KwArgs, RArray, RHash, Ruby, Symbol, TryConvert, Value,
 };
 use parquet::basic::Compression;
 use parquet_core::ParquetValue;
 
-use crate::types::{ColumnEnumeratorArgs, ParquetWriteArgs, RowEnumeratorArgs};
+use crate::types::{BloomFilterConfig, ColumnEnumeratorArgs, ParquetWriteArgs, RowEnumeratorArgs};
 
 /// Estimate the memory size of a ParquetValue
 pub fn estimate_parquet_value_size(value: &ParquetValue) -> usize {
@@ -96,6 +96,7 @@ pub fn parse_parquet_write_args(
             Option<Option<usize>>,
             Option<Option<Value>>,
             Option<Option<bool>>,
+            Option<Option<Value>>, // bloom_filters
         ),
         (),
     >(
@@ -108,8 +109,62 @@ pub fn parse_parquet_write_args(
             "sample_size",
             "logger",
             "string_cache",
+            "bloom_filters",
         ],
     )?;
+
+    // Parse bloom_filters: array of hashes
+    let bloom_filters = if let Some(bf_val) = kwargs.optional.6.flatten() {
+        if bf_val.is_kind_of(_ruby.class_array()) {
+            let arr: RArray = <RArray as TryConvert>::try_convert(bf_val)?;
+            let mut out: Vec<BloomFilterConfig> = Vec::with_capacity(arr.len());
+            for entry in arr.into_iter() {
+                let hash: RHash = <RHash as TryConvert>::try_convert(entry)?;
+                // path should always be an array of strings
+                let path_value = hash
+                    .fetch::<_, Value>(Symbol::new("path"))
+                    .map_err(|e| MagnusError::new(magnus::exception::arg_error(), format!("bloom_filters entry missing 'path' key: {}", e)))?;
+                
+                // Expect path to always be an array
+                if !path_value.is_kind_of(_ruby.class_array()) {
+                    return Err(MagnusError::new(
+                        magnus::exception::arg_error(),
+                        "bloom_filters 'path' must be an Array of column name parts (e.g., ['column_name'] or ['parent', 'child'])",
+                    ));
+                }
+                
+                let pa: RArray = <RArray as TryConvert>::try_convert(path_value)?;
+                let mut path = Vec::with_capacity(pa.len());
+                for p in pa.into_iter() {
+                    let s: String = <String as TryConvert>::try_convert(p)?;
+                    path.push(s);
+                };
+
+                let fpp = hash
+                    .fetch::<_, Value>(Symbol::new("false_positive_probability"))
+                    .ok()
+                    .and_then(|v| <f64 as TryConvert>::try_convert(v).ok());
+                let ndv = hash
+                    .fetch::<_, Value>(Symbol::new("n_distinct_values"))
+                    .ok()
+                    .and_then(|v| <u64 as TryConvert>::try_convert(v).ok());
+
+                out.push(BloomFilterConfig {
+                    path,
+                    false_positive_probability: fpp,
+                    n_distinct_values: ndv,
+                });
+            }
+            Some(out)
+        } else {
+            return Err(MagnusError::new(
+                magnus::exception::arg_error(),
+                "bloom_filters must be an Array of Hashes",
+            ));
+        }
+    } else {
+        None
+    };
 
     Ok(ParquetWriteArgs {
         read_from,
@@ -121,6 +176,7 @@ pub fn parse_parquet_write_args(
         sample_size: kwargs.optional.3.flatten(),
         logger: kwargs.optional.4.flatten(),
         string_cache: kwargs.optional.5.flatten(),
+        bloom_filters,
     })
 }
 

--- a/ext/parquet-ruby-adapter/src/writer.rs
+++ b/ext/parquet-ruby-adapter/src/writer.rs
@@ -21,16 +21,10 @@ pub fn create_writer(
     let compression_setting = parse_compression(compression)?;
     let mut builder = WriterProperties::builder();
     builder = builder.set_compression(compression_setting);
-    
-    // Default max row group size in parquet-rs is 1048576 (1M rows)
-    // We'll use this to cap NDV values since bloom filters are per row group
+
     const DEFAULT_MAX_ROW_GROUP_SIZE: u64 = 1048576;
 
     if let Some(configs) = bloom_filters {
-        // Enable bloom filters globally when any config provided
-        builder = builder.set_bloom_filter_enabled(true);
-
-        // Enable and configure per-column bloom filter settings
         for cfg in configs {
             let col_path = ColumnPath::new(cfg.path.clone());
             builder = builder.set_column_bloom_filter_enabled(col_path.clone(), true);

--- a/ext/parquet-ruby-adapter/src/writer.rs
+++ b/ext/parquet-ruby-adapter/src/writer.rs
@@ -1,6 +1,7 @@
 use magnus::value::ReprValue;
 use magnus::{Error as MagnusError, Ruby, TryConvert, Value};
 use parquet::file::properties::WriterProperties;
+use parquet::schema::types::ColumnPath;
 use parquet_core::Schema;
 use std::io::{BufReader, BufWriter, Write};
 use tempfile::NamedTempFile;
@@ -15,11 +16,38 @@ pub fn create_writer(
     write_to: Value,
     schema: Schema,
     compression: Option<String>,
+    bloom_filters: Option<Vec<crate::types::BloomFilterConfig>>,
 ) -> Result<WriterOutput, MagnusError> {
     let compression_setting = parse_compression(compression)?;
-    let props = WriterProperties::builder()
-        .set_compression(compression_setting)
-        .build();
+    let mut builder = WriterProperties::builder();
+    builder = builder.set_compression(compression_setting);
+    
+    // Default max row group size in parquet-rs is 1048576 (1M rows)
+    // We'll use this to cap NDV values since bloom filters are per row group
+    const DEFAULT_MAX_ROW_GROUP_SIZE: u64 = 1048576;
+
+    if let Some(configs) = bloom_filters {
+        // Enable bloom filters globally when any config provided
+        builder = builder.set_bloom_filter_enabled(true);
+
+        // Enable and configure per-column bloom filter settings
+        for cfg in configs {
+            let col_path = ColumnPath::new(cfg.path.clone());
+            builder = builder.set_column_bloom_filter_enabled(col_path.clone(), true);
+
+            if let Some(fpp) = cfg.false_positive_probability {
+                builder = builder.set_column_bloom_filter_fpp(col_path.clone(), fpp);
+            }
+            if let Some(ndv) = cfg.n_distinct_values {
+                // Cap NDV to row group size since bloom filters are per row group
+                // This prevents creating unnecessarily large bloom filters
+                let capped_ndv = ndv.min(DEFAULT_MAX_ROW_GROUP_SIZE);
+                builder = builder.set_column_bloom_filter_ndv(col_path.clone(), capped_ndv);
+            }
+        }
+    }
+
+    let props = builder.build();
 
     if write_to.is_kind_of(ruby.class_string()) {
         // Direct file path
@@ -147,6 +175,7 @@ pub fn write_rows(
         write_args.write_to,
         schema.clone(),
         write_args.compression,
+        write_args.bloom_filters.clone(),
     )?;
 
     // Create logger
@@ -335,6 +364,7 @@ pub fn write_columns(
         write_args.write_to,
         schema.clone(),
         write_args.compression,
+        write_args.bloom_filters.clone(),
     )?;
 
     // Get column names from schema

--- a/lib/parquet.rbi
+++ b/lib/parquet.rbi
@@ -92,7 +92,8 @@ module Parquet
       batch_size: T.nilable(Integer),
       flush_threshold: T.nilable(Integer),
       compression: T.nilable(String),
-      sample_size: T.nilable(Integer)
+      sample_size: T.nilable(Integer),
+      bloom_filters: T.nilable(T::Array[T::Hash[Symbol, T.untyped]])
     ).void
   end
   def self.write_rows(
@@ -102,7 +103,8 @@ module Parquet
     batch_size: nil,
     flush_threshold: nil,
     compression: nil,
-    sample_size: nil
+    sample_size: nil,
+    bloom_filters: nil
   )
   end
 
@@ -128,9 +130,10 @@ module Parquet
       schema: T::Array[T::Hash[String, String]],
       write_to: T.any(String, IO),
       flush_threshold: T.nilable(Integer),
-      compression: T.nilable(String)
+      compression: T.nilable(String),
+      bloom_filters: T.nilable(T::Array[T::Hash[Symbol, T.untyped]])
     ).void
   end
-  def self.write_columns(read_from, schema:, write_to:, flush_threshold: nil, compression: nil)
+  def self.write_columns(read_from, schema:, write_to:, flush_threshold: nil, compression: nil, bloom_filters: nil)
   end
 end

--- a/test/bloom_filter_test.rb
+++ b/test/bloom_filter_test.rb
@@ -1,0 +1,231 @@
+require_relative 'test_helper'
+require 'tempfile'
+
+class BloomFilterTest < Minitest::Test
+  def setup
+    @file = File.join(Dir.tmpdir, "bf_#{Process.pid}.parquet")
+  end
+
+  def teardown
+    File.delete(@file) if File.exist?(@file)
+  end
+
+  def schema
+    {
+      fields: [
+        { name: 'uuid', type: :fixed_len_byte_array, length: 16, format: 'uuid', nullable: false },
+        { name: 'device_id', type: :string },
+        { name: 'value', type: :int64 }
+      ]
+    }
+  end
+
+  def test_write_rows_with_bloom_filters
+    require 'securerandom'
+    # Generate data
+    data = (0...10_000).map do |i|
+      [SecureRandom.uuid, "dev-#{i % 1000}", i]
+    end
+
+    # Write with bloom filters on uuid and device_id
+    Parquet.write_rows(
+      data,
+      schema: schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['uuid'], false_positive_probability: 0.01, n_distinct_values: 10_000 },
+        { path: ['device_id'], false_positive_probability: 0.01, n_distinct_values: 1_000 }
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    # Ensure bloom filter metadata is present for at least one column chunk
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata to be present"
+  end
+
+  def test_write_columns_with_bloom_filters
+    require 'securerandom'
+    uuids = Array.new(5000) { SecureRandom.uuid }
+    devices = Array.new(5000) { |i| "dev-#{i % 500}" }
+    values = (0...5000).to_a
+
+    batches = [[uuids, devices, values]]
+
+    Parquet.write_columns(
+      batches.each,
+      schema: schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['uuid'], false_positive_probability: 0.01, n_distinct_values: 5000 },
+        { path: ['device_id'], false_positive_probability: 0.01, n_distinct_values: 500 }
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata to be present for column write"
+  end
+
+  def test_bloom_filter_with_defaults
+    require 'securerandom'
+    # Generate data
+    data = (0...1000).map do |i|
+      [SecureRandom.uuid, "dev-#{i % 100}", i]
+    end
+
+    # Write with bloom filters using defaults
+    Parquet.write_rows(
+      data,
+      schema: schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['uuid'] },  # Use default fpp and ndv
+        { path: ['device_id'], false_positive_probability: 0.05 }  # Custom fpp, default ndv
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    # Ensure bloom filter metadata is present
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata when using defaults"
+  end
+
+  def test_bloom_filter_single_element_array
+    require 'securerandom'
+    # Generate data
+    data = (0...1000).map do |i|
+      [SecureRandom.uuid, "dev-#{i % 100}", i]
+    end
+
+    # Test that single-element arrays work correctly
+    Parquet.write_rows(
+      data,
+      schema: schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['uuid'], false_positive_probability: 0.01, n_distinct_values: 1000 },
+        { path: ['device_id'], false_positive_probability: 0.01, n_distinct_values: 100 }
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    # Ensure bloom filter metadata is present
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata for single-element path arrays"
+  end
+
+  def test_bloom_filter_nested_column
+    nested_schema = {
+      fields: [
+        { name: 'id', type: :int64 },
+        { 
+          name: 'user', 
+          type: :struct,
+          fields: [
+            { name: 'email', type: :string },
+            { name: 'name', type: :string }
+          ]
+        }
+      ]
+    }
+
+    data = (0...1000).map do |i|
+      [i, { "email" => "user#{i}@example.com", "name" => "User #{i}" }]
+    end
+
+    # Write with bloom filter on nested column
+    Parquet.write_rows(
+      data,
+      schema: nested_schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['user', 'email'], false_positive_probability: 0.01, n_distinct_values: 1000 }
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    # Ensure bloom filter metadata is present
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata for nested column"
+  end
+
+  def test_no_bloom_filters
+    require 'securerandom'
+    # Generate data
+    data = (0...1000).map do |i|
+      [SecureRandom.uuid, "dev-#{i % 100}", i]
+    end
+
+    # Write without bloom filters
+    Parquet.write_rows(
+      data,
+      schema: schema,
+      write_to: @file
+    )
+
+    md = Parquet.metadata(@file)
+    # Ensure NO bloom filter metadata is present
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    refute has_bf, "Should not have bloom filter metadata when not specified"
+  end
+
+  def test_ndv_capping_to_row_group_size
+    require 'securerandom'
+    # Generate small dataset
+    data = (0...100).map do |i|
+      [SecureRandom.uuid, "dev-#{i}", i]
+    end
+
+    # Write with NDV much larger than actual data
+    # The NDV should be capped to max row group size (1M) internally
+    # This ensures bloom filter isn't unnecessarily large
+    Parquet.write_rows(
+      data,
+      schema: schema,
+      write_to: @file,
+      bloom_filters: [
+        { path: ['uuid'], false_positive_probability: 0.01, n_distinct_values: 10_000_000 },  # 10M NDV
+        { path: ['device_id'], false_positive_probability: 0.01, n_distinct_values: 5_000_000 }  # 5M NDV
+      ]
+    )
+
+    md = Parquet.metadata(@file)
+    # Verify bloom filters were created
+    has_bf = md["row_groups"].any? do |rg|
+      rg["columns"].any? { |c| c.key?("bloom_filter_offset") || c.key?("bloom_filter_length") }
+    end
+    assert has_bf, "Expected bloom filter metadata even with large NDV"
+    
+    # The bloom filter size should be reasonable (not excessively large)
+    # With NDV capped at 1M and FPP 0.01, theoretical size is ~1.2MB
+    # But the actual implementation may round up to power of 2, so ~2MB is expected
+    md["row_groups"].each do |rg|
+      rg["columns"].each do |col|
+        if col["bloom_filter_length"]
+          # Bloom filter for 10M values at 0.01 FPP would be ~14.3MB
+          # With capping to 1M, it should be much smaller (~2MB)
+          assert col["bloom_filter_length"] < 3_000_000, 
+            "Bloom filter size should be capped (got #{col["bloom_filter_length"]} bytes)"
+          # Also verify it's not too small (should be at least 1KB for any reasonable filter)
+          assert col["bloom_filter_length"] > 1000,
+            "Bloom filter seems too small (got #{col["bloom_filter_length"]} bytes)"
+        end
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
## Summary

  This PR adds comprehensive bloom filter support to parquet-ruby, enabling significant query performance improvements when reading Parquet files with filter predicates.

  ## What are Bloom Filters?

  Bloom filters are space-efficient probabilistic data structures that can tell us if an element is definitely NOT in a set. In Parquet, they allow query engines to skip entire row groups
  (up to 1M rows) that don't contain the values being searched for, dramatically improving query performance for high-cardinality columns.

  ## Implementation Details

  ### API Design

  The bloom filter configuration uses a consistent array-based path format:

  ```ruby
  Parquet.write_rows(data,
    schema: schema,
    write_to: "output.parquet",
    bloom_filters: [
      { path: ['uuid'], false_positive_probability: 0.01, n_distinct_values: 10_000 },
      { path: ['device_id'] },  # Uses defaults: FPP=0.05, NDV=1M
      { path: ['user', 'email'] }  # Nested column support
    ]
  )

  Key Features

  1. Consistent API: path is always an array for type consistency
    - Top-level: ['column_name']
    - Nested: ['parent', 'child']
  2. Smart NDV Capping: Automatically caps n_distinct_values to row group size (1M) to prevent unnecessarily large bloom filters
  3. Per Row Group: Bloom filters are created per row group, not per file, enabling fine-grained filtering
  4. Configurable Parameters:
    - false_positive_probability: Target FPP (default: 0.05)
    - n_distinct_values: Expected distinct values (default: 1M)

  Performance Characteristics

  | Distinct Values | FPP = 0.01 | FPP = 0.05 | FPP = 0.1 |
  |-----------------|------------|------------|-----------|
  | 1,000           | 1.5 KB     | 1 KB       | 0.7 KB    |
  | 10,000          | 16 KB      | 10 KB      | 7 KB      |
  | 100,000         | 150 KB     | 100 KB     | 70 KB     |
  | 1,000,000       | 1.5 MB     | 1 MB       | 700 KB    |

  Testing

  Added comprehensive test suite covering:
  - Basic bloom filter usage with write_rows and write_columns
  - Default value handling
  - Single-element array paths
  - Nested column support
  - NDV capping behavior
  - Verification that bloom filters are omitted when not configured

  Documentation

  Updated README with:
  - Detailed bloom filter section explaining usage and configuration
  - When to use bloom filters (high-cardinality columns)
  - Trade-offs and performance considerations
  - Size estimation table

  Breaking Changes

  None. This is a purely additive feature that doesn't affect existing code.

  Future Enhancements

  Potential future improvements could include:
  - Custom row group size configuration
  - Bloom filter statistics in metadata API
  - Per-column-type automatic bloom filter recommendations

  Checklist

  - Implementation complete
  - Tests passing
  - Documentation updated
  - No breaking changes