### PR TITLE
Remote source (S3 Range GET) support with row‑group pruning

### DIFF
--- a/ext/parquet-core/src/reader.rs
+++ b/ext/parquet-core/src/reader.rs
@@ -32,17 +32,7 @@ where
     ///
     /// Returns an iterator over rows where each row is a vector of ParquetValues
     pub fn read_rows(self) -> Result<RowIterator<R>> {
-        let builder = ParquetRecordBatchReaderBuilder::try_new(self.inner)?;
-        let metadata = builder.metadata().clone();
-        let reader = builder.build()?;
-
-        Ok(RowIterator {
-            batch_reader: reader,
-            metadata,
-            current_batch: None,
-            current_row: 0,
-            _phantom: std::marker::PhantomData,
-        })
+        self.read_rows_with_selection(None, None)
     }
 
     /// Read rows with column projection
@@ -50,22 +40,46 @@ where
     /// Only the specified columns will be read, which can significantly
     /// improve performance for wide tables.
     pub fn read_rows_with_projection(self, columns: &[String]) -> Result<RowIterator<R>> {
-        let mut builder = ParquetRecordBatchReaderBuilder::try_new(self.inner)?;
-        let arrow_schema = builder.schema();
+        self.read_rows_with_selection(Some(columns), None)
+    }
 
-        // Create projection mask based on column names
-        let mut column_indices = Vec::new();
-        for (idx, field) in arrow_schema.fields().iter().enumerate() {
-            if columns.contains(&field.name().to_string()) {
-                column_indices.push(idx);
+    /// Read rows with optional projection and row-group pruning
+    pub fn read_rows_with_selection(
+        self,
+        columns: Option<&[String]>,
+        row_groups: Option<&[usize]>,
+    ) -> Result<RowIterator<R>> {
+        let mut builder = ParquetRecordBatchReaderBuilder::try_new(self.inner)?;
+
+        if let Some(groups) = row_groups {
+            if !groups.is_empty() {
+                builder = builder.with_row_groups(groups.to_vec());
             }
         }
 
-        // Allow empty column projections to match v1 behavior
-        // This will result in rows with no fields
+        if let Some(cols) = columns {
+            let arrow_schema = builder.schema();
+            let mut column_indices = Vec::new();
+            for (idx, field) in arrow_schema.fields().iter().enumerate() {
+                if cols.contains(&field.name().to_string()) {
+                    column_indices.push(idx);
+                }
+            }
 
-        let mask = parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), column_indices);
-        builder = builder.with_projection(mask);
+            if column_indices.is_empty() {
+                // Ensure at least one column is requested for Arrow reader
+                if !arrow_schema.fields().is_empty() {
+                    column_indices.push(0);
+                }
+            }
+
+            if !column_indices.is_empty() {
+                let mask =
+                    parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), column_indices);
+                builder = builder.with_projection(mask);
+            }
+        }
+
         let metadata = builder.metadata().clone();
         let reader = builder.build()?;
 
@@ -83,26 +97,7 @@ where
     /// Returns an iterator over column batches where each batch contains
     /// arrays of values for each column.
     pub fn read_columns(self, batch_size: Option<usize>) -> Result<ColumnIterator<R>> {
-        let mut builder = ParquetRecordBatchReaderBuilder::try_new(self.inner)?;
-
-        let is_empty = builder.metadata().file_metadata().num_rows() == 0;
-
-        if let Some(size) = batch_size {
-            builder = builder.with_batch_size(size);
-        }
-
-        let schema = builder.schema().clone();
-        let metadata = builder.metadata().clone();
-        let reader = builder.build()?;
-
-        Ok(ColumnIterator {
-            batch_reader: reader,
-            metadata,
-            schema,
-            returned_empty_batch: false,
-            is_empty_file: is_empty,
-            _phantom: std::marker::PhantomData,
-        })
+        self.read_columns_with_selection(None, None, batch_size)
     }
 
     /// Read columns with projection
@@ -111,24 +106,47 @@ where
         columns: &[String],
         batch_size: Option<usize>,
     ) -> Result<ColumnIterator<R>> {
+        self.read_columns_with_selection(Some(columns), None, batch_size)
+    }
+
+    /// Read columns with optional projection and row-group pruning
+    pub fn read_columns_with_selection(
+        self,
+        columns: Option<&[String]>,
+        row_groups: Option<&[usize]>,
+        batch_size: Option<usize>,
+    ) -> Result<ColumnIterator<R>> {
         let mut builder = ParquetRecordBatchReaderBuilder::try_new(self.inner)?;
-        let arrow_schema = builder.schema();
 
-        let is_empty = builder.metadata().file_metadata().num_rows() == 0;
-
-        // Create projection mask
-        let mut column_indices = Vec::new();
-        for (idx, field) in arrow_schema.fields().iter().enumerate() {
-            if columns.contains(&field.name().to_string()) {
-                column_indices.push(idx);
+        if let Some(groups) = row_groups {
+            if !groups.is_empty() {
+                builder = builder.with_row_groups(groups.to_vec());
             }
         }
 
-        // Allow empty column projections to match v1 behavior
-        // This will result in rows with no fields
+        if let Some(cols) = columns {
+            let arrow_schema = builder.schema();
+            let mut column_indices = Vec::new();
+            for (idx, field) in arrow_schema.fields().iter().enumerate() {
+                if cols.contains(&field.name().to_string()) {
+                    column_indices.push(idx);
+                }
+            }
 
-        let mask = parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), column_indices);
-        builder = builder.with_projection(mask);
+            if column_indices.is_empty() {
+                if !arrow_schema.fields().is_empty() {
+                    column_indices.push(0);
+                }
+            }
+
+            if !column_indices.is_empty() {
+                let mask =
+                    parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), column_indices);
+                builder = builder.with_projection(mask);
+            }
+        }
+
+        let is_empty = builder.metadata().file_metadata().num_rows() == 0;
 
         if let Some(size) = batch_size {
             builder = builder.with_batch_size(size);

--- a/ext/parquet-ruby-adapter/src/chunk_reader.rs
+++ b/ext/parquet-ruby-adapter/src/chunk_reader.rs
@@ -11,6 +11,7 @@ use std::io::{self, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::io::ThreadSafeRubyIOReader;
+use crate::remote::{RemoteRangeReader, ThreadSafeRemoteSource};
 
 /// A ChunkReader that can be cloned for parallel reading
 #[derive(Clone)]
@@ -19,6 +20,8 @@ pub enum CloneableChunkReader {
     File(FileChunkReader),
     /// Ruby IO-based reader using thread-safe wrapper
     RubyIO(RubyIOChunkReader),
+    /// Remote reader backed by Ruby read_range callbacks
+    Remote(RemoteChunkReader),
     /// In-memory bytes (fallback for small files)
     Bytes(bytes::Bytes),
 }
@@ -46,6 +49,18 @@ impl FileChunkReader {
 pub struct RubyIOChunkReader {
     reader: ThreadSafeRubyIOReader,
     len: u64,
+}
+/// Remote chunk reader built on top of custom read_range callbacks
+#[derive(Clone)]
+pub struct RemoteChunkReader {
+    source: ThreadSafeRemoteSource,
+    len: u64,
+}
+
+impl RemoteChunkReader {
+    pub(crate) fn new(source: ThreadSafeRemoteSource, len: u64) -> Self {
+        Self { source, len }
+    }
 }
 
 impl RubyIOChunkReader {
@@ -101,11 +116,18 @@ impl Length for RubyIOChunkReader {
     }
 }
 
+impl Length for RemoteChunkReader {
+    fn len(&self) -> u64 {
+        self.len
+    }
+}
+
 impl Length for CloneableChunkReader {
     fn len(&self) -> u64 {
         match self {
             CloneableChunkReader::File(f) => f.len(),
             CloneableChunkReader::RubyIO(r) => r.len(),
+            CloneableChunkReader::Remote(r) => r.len(),
             CloneableChunkReader::Bytes(b) => b.len() as u64,
         }
     }
@@ -117,21 +139,21 @@ impl ChunkReader for FileChunkReader {
 
     fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
         let file = File::open(&self.path)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         let reader = RangeReader::new(file, start, self.file_len - start)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         Ok(Box::new(reader))
     }
 
     fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<Bytes> {
         let mut file = File::open(&self.path)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         file.seek(SeekFrom::Start(start))
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
 
         let mut buf = vec![0; length];
         file.read_exact(&mut buf)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         Ok(Bytes::from(buf))
     }
 }
@@ -147,11 +169,11 @@ impl ChunkReader for RubyIOChunkReader {
         // Seek to the start position
         reader
             .seek(SeekFrom::Start(start))
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
 
         // Create a range reader that limits reading to the available data
         let reader = RangeReader::new(reader, start, self.len - start)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         Ok(Box::new(reader))
     }
 
@@ -159,13 +181,45 @@ impl ChunkReader for RubyIOChunkReader {
         let mut reader = self.reader.clone();
         reader
             .seek(SeekFrom::Start(start))
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
 
         let mut buf = vec![0; length];
         reader
             .read_exact(&mut buf)
-            .map_err(|e| parquet::errors::ParquetError::External(Box::new(e)))?;
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))?;
         Ok(Bytes::from(buf))
+    }
+}
+
+// Implement ChunkReader for RemoteChunkReader
+impl ChunkReader for RemoteChunkReader {
+    type T = Box<dyn Read + Send>;
+
+    fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+        if start > self.len {
+            return Err(parquet::errors::ParquetError::EOF(format!(
+                "Attempted to read beyond remote object length (start {}, len {})",
+                start, self.len
+            )));
+        }
+
+        let reader = RemoteRangeReader::new(self.source.clone(), start, self.len - start);
+        Ok(Box::new(reader))
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<Bytes> {
+        if start > self.len {
+            return Err(parquet::errors::ParquetError::EOF(format!(
+                "Attempted to read beyond remote object length (start {}, len {})",
+                start, self.len
+            )));
+        }
+
+        let end = start.saturating_add(length as u64).min(self.len);
+        let length = (end - start) as usize;
+        self.source
+            .read_range(start, length)
+            .map_err(|e| parquet::errors::ParquetError::General(e.to_string()))
     }
 }
 
@@ -177,6 +231,7 @@ impl ChunkReader for CloneableChunkReader {
         match self {
             CloneableChunkReader::File(f) => f.get_read(start),
             CloneableChunkReader::RubyIO(r) => r.get_read(start),
+            CloneableChunkReader::Remote(r) => r.get_read(start),
             CloneableChunkReader::Bytes(b) => {
                 // For bytes, we can use the built-in implementation
                 let bytes = b.clone();
@@ -197,6 +252,7 @@ impl ChunkReader for CloneableChunkReader {
         match self {
             CloneableChunkReader::File(f) => f.get_bytes(start, length),
             CloneableChunkReader::RubyIO(r) => r.get_bytes(start, length),
+            CloneableChunkReader::Remote(r) => r.get_bytes(start, length),
             CloneableChunkReader::Bytes(b) => {
                 // For bytes, use the built-in slice functionality
                 let end = (start as usize).saturating_add(length).min(b.len());
@@ -228,6 +284,16 @@ impl CloneableChunkReader {
     /// Create from bytes (for small files or testing)
     pub fn from_bytes(bytes: Bytes) -> Self {
         CloneableChunkReader::Bytes(bytes)
+    }
+
+    /// Create from a remote source implementing read_range and length
+    pub(crate) fn from_remote(source: ThreadSafeRemoteSource) -> Result<Self> {
+        let len = source
+            .len()
+            .map_err(|e| parquet_core::ParquetError::invalid_argument(e.to_string()))?;
+        Ok(CloneableChunkReader::Remote(RemoteChunkReader::new(
+            source, len,
+        )))
     }
 
     /// Check if this reader should use streaming (based on size threshold)

--- a/ext/parquet-ruby-adapter/src/lib.rs
+++ b/ext/parquet-ruby-adapter/src/lib.rs
@@ -43,6 +43,8 @@ pub use error::{ErrorContext, IntoMagnusError, Result, RubyAdapterError};
 pub mod chunk_reader;
 pub use chunk_reader::CloneableChunkReader;
 
+mod remote;
+
 pub mod converter;
 pub use converter::RubyValueConverter;
 

--- a/ext/parquet-ruby-adapter/src/metadata.rs
+++ b/ext/parquet-ruby-adapter/src/metadata.rs
@@ -462,6 +462,59 @@ impl TryIntoValue for RubyParquetMetaData {
                 .aset("columns", columns_array)
                 .map_err(|e| RubyAdapterError::metadata(format!("Failed to set columns: {}", e)))?;
 
+            // Add row group level statistics for quick pruning
+            let stats_hash = handle.hash_new();
+            let mut has_stats = false;
+            for (col_idx, column) in row_group.columns().iter().enumerate() {
+                if let Some(stats) = column.statistics() {
+                    let col_stats_hash = handle.hash_new();
+                    if let Some(min_bytes) = stats.min_bytes_opt() {
+                        col_stats_hash
+                            .aset("min_bytes", handle.str_from_slice(min_bytes))
+                            .map_err(|e| {
+                                RubyAdapterError::metadata(format!(
+                                    "Failed to set min_bytes for column {}: {}",
+                                    col_idx, e
+                                ))
+                            })?;
+                    }
+                    if let Some(max_bytes) = stats.max_bytes_opt() {
+                        col_stats_hash
+                            .aset("max_bytes", handle.str_from_slice(max_bytes))
+                            .map_err(|e| {
+                                RubyAdapterError::metadata(format!(
+                                    "Failed to set max_bytes for column {}: {}",
+                                    col_idx, e
+                                ))
+                            })?;
+                    }
+                    if let Some(null_count) = stats.null_count_opt() {
+                        col_stats_hash.aset("null_count", null_count).map_err(|e| {
+                            RubyAdapterError::metadata(format!(
+                                "Failed to set null_count for column {}: {}",
+                                col_idx, e
+                            ))
+                        })?;
+                    }
+                    if !col_stats_hash.is_empty() {
+                        has_stats = true;
+                        stats_hash
+                            .aset(col_idx as i64, col_stats_hash)
+                            .map_err(|e| {
+                                RubyAdapterError::metadata(format!(
+                                    "Failed to set column stats for column {}: {}",
+                                    col_idx, e
+                                ))
+                            })?;
+                    }
+                }
+            }
+            if has_stats {
+                rg_hash.aset("statistics", stats_hash).map_err(|e| {
+                    RubyAdapterError::metadata(format!("Failed to set row group statistics: {}", e))
+                })?;
+            }
+
             row_groups_array.push(rg_hash).map_err(|e| {
                 RubyAdapterError::metadata(format!("Failed to push rg_hash: {}", e))
             })?;

--- a/ext/parquet-ruby-adapter/src/reader.rs
+++ b/ext/parquet-ruby-adapter/src/reader.rs
@@ -2,6 +2,7 @@ use magnus::value::ReprValue;
 use magnus::{Error as MagnusError, IntoValue, RArray, RHash, Ruby, TryConvert, Value};
 use parquet_core::reader::Reader;
 
+use crate::remote::{RemoteSource, ThreadSafeRemoteSource};
 use crate::StringCache;
 use crate::{
     converter::parquet_to_ruby,
@@ -19,6 +20,7 @@ pub fn each_row(
     to_read: Value,
     result_type: ParserResultType,
     columns: Option<Vec<String>>,
+    row_groups: Option<Vec<usize>>,
     strict: bool,
     logger: RubyLogger,
 ) -> Result<Value, MagnusError> {
@@ -28,6 +30,7 @@ pub fn each_row(
             to_read,
             result_type,
             columns: columns.clone(),
+            row_groups: row_groups.clone(),
             strict,
             logger: logger.inner(),
         })
@@ -53,6 +56,13 @@ pub fn each_row(
         let thread_safe_reader = ThreadSafeRubyIOReader::new(ruby_reader);
 
         CloneableChunkReader::from_ruby_io(thread_safe_reader)
+            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?
+    } else if to_read.respond_to("read_range", false)? {
+        // Treat as remote source
+        let source = RemoteSource::new(to_read)
+            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+        let reader = ThreadSafeRemoteSource::new(source);
+        CloneableChunkReader::from_remote(reader)
             .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?
     } else {
         return Err(MagnusError::new(
@@ -80,17 +90,60 @@ pub fn each_row(
 
     let _ = logger.info(|| format!("Processing {} columns", all_column_names.len()));
 
-    // Get the row iterator
-    let (row_iter, column_names) = if let Some(ref cols) = columns {
-        let iter = reader
-            .read_rows_with_projection(cols)
-            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
-        (iter, cols.clone())
+    // Validate requested columns when strict mode is enabled
+    if let Some(ref cols) = columns {
+        if strict {
+            for col in cols {
+                if !all_column_names.iter().any(|name| name == col) {
+                    return Err(MagnusError::new(
+                        ruby.exception_runtime_error(),
+                        format!("Column #{col} not found in Parquet schema"),
+                    ));
+                }
+            }
+        }
+    }
+
+    let effective_columns = if let Some(cols) = columns.clone() {
+        if strict {
+            Some(cols)
+        } else {
+            let filtered: Vec<String> = cols
+                .into_iter()
+                .filter(|col| all_column_names.iter().any(|name| name == col))
+                .collect();
+            Some(filtered)
+        }
     } else {
-        let iter = reader
-            .read_rows()
-            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
-        (iter, all_column_names)
+        None
+    };
+
+    // Get the row iterator
+    let (row_iter, column_names) = match (effective_columns.as_ref(), row_groups.as_ref()) {
+        (Some(cols), Some(groups)) => {
+            let iter = reader
+                .read_rows_with_selection(Some(cols), Some(groups))
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, cols.clone())
+        }
+        (Some(cols), None) => {
+            let iter = reader
+                .read_rows_with_selection(Some(cols), None)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, cols.clone())
+        }
+        (None, Some(groups)) => {
+            let iter = reader
+                .read_rows_with_selection(None, Some(groups))
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, all_column_names.clone())
+        }
+        (None, None) => {
+            let iter = reader
+                .read_rows_with_selection(None, None)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, all_column_names)
+        }
     };
 
     // Process with block
@@ -158,6 +211,7 @@ struct EachColumnArgs {
     result_type: ParserResultType,
     columns: Option<Vec<String>>,
     batch_size: Option<usize>,
+    row_groups: Option<Vec<usize>>,
     strict: bool,
     logger: RubyLogger,
 }
@@ -171,6 +225,7 @@ pub fn each_column(
     result_type: ParserResultType,
     columns: Option<Vec<String>>,
     batch_size: Option<usize>,
+    row_groups: Option<Vec<usize>>,
     strict: bool,
     logger: RubyLogger,
 ) -> Result<Value, MagnusError> {
@@ -180,6 +235,7 @@ pub fn each_column(
         result_type,
         columns,
         batch_size,
+        row_groups,
         strict,
         logger,
     };
@@ -194,6 +250,7 @@ fn each_column_impl(ruby: &Ruby, args: EachColumnArgs) -> Result<Value, MagnusEr
             result_type: args.result_type,
             columns: args.columns.clone(),
             batch_size: args.batch_size,
+            row_groups: args.row_groups.clone(),
             strict: args.strict,
             logger: args.logger.inner(),
         })
@@ -226,6 +283,12 @@ fn each_column_impl(ruby: &Ruby, args: EachColumnArgs) -> Result<Value, MagnusEr
 
         CloneableChunkReader::from_ruby_io(thread_safe_reader)
             .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?
+    } else if args.to_read.respond_to("read_range", false)? {
+        let source = RemoteSource::new(args.to_read)
+            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+        let reader = ThreadSafeRemoteSource::new(source);
+        CloneableChunkReader::from_remote(reader)
+            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?
     } else {
         return Err(MagnusError::new(
             ruby.exception_runtime_error(),
@@ -250,17 +313,53 @@ fn each_column_impl(ruby: &Ruby, args: EachColumnArgs) -> Result<Value, MagnusEr
         .map(|f| f.name().to_string())
         .collect();
 
-    // Get the column iterator
-    let (col_iter, _column_names) = if let Some(ref cols) = args.columns {
-        let iter = reader
-            .read_columns_with_projection(cols, args.batch_size)
-            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
-        (iter, cols.clone())
+    // Determine effective columns under strict/non-strict behavior
+    let effective_columns: Option<Vec<String>> = if let Some(cols) = args.columns.clone() {
+        if args.strict {
+            Some(cols)
+        } else {
+            let filtered: Vec<String> = cols
+                .into_iter()
+                .filter(|c| all_column_names.iter().any(|n| n == c))
+                .collect();
+            Some(filtered)
+        }
     } else {
-        let iter = reader
-            .read_columns(args.batch_size)
-            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
-        (iter, all_column_names)
+        None
+    };
+    let force_empty = args.columns.is_some()
+        && effective_columns
+            .as_ref()
+            .map(|v| v.is_empty())
+            .unwrap_or(false)
+        && !args.strict;
+
+    // Get the column iterator
+    let (col_iter, _column_names) = match (if force_empty { None } else { effective_columns.as_ref() }, args.row_groups.as_ref()) {
+        (Some(cols), Some(groups)) => {
+            let iter = reader
+                .read_columns_with_selection(Some(cols), Some(groups), args.batch_size)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, cols.clone())
+        }
+        (Some(cols), None) => {
+            let iter = reader
+                .read_columns_with_selection(Some(cols), None, args.batch_size)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, cols.clone())
+        }
+        (None, Some(groups)) => {
+            let iter = reader
+                .read_columns_with_selection(None, Some(groups), args.batch_size)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, all_column_names.clone())
+        }
+        (None, None) => {
+            let iter = reader
+                .read_columns_with_selection(None, None, args.batch_size)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            (iter, all_column_names)
+        }
     };
 
     // Process with block
@@ -277,34 +376,41 @@ fn each_column_impl(ruby: &Ruby, args: EachColumnArgs) -> Result<Value, MagnusEr
             .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
 
         // Convert batch to Ruby value based on result_type
-        let ruby_batch = match args.result_type {
-            ParserResultType::Array => {
-                let array: RArray = ruby.ary_new_capa(batch.columns.len());
-                for (_name, values) in batch.columns {
-                    let col_array: RArray = ruby.ary_new_capa(values.len());
-                    for value in values {
-                        let ruby_value = parquet_to_ruby(value).map_err(|e| {
-                            MagnusError::new(ruby.exception_runtime_error(), e.to_string())
-                        })?;
-                        col_array.push(ruby_value)?;
-                    }
-                    array.push(col_array)?;
-                }
-                array.as_value()
+        let ruby_batch = if force_empty {
+            match args.result_type {
+                ParserResultType::Array => ruby.ary_new().as_value(),
+                ParserResultType::Hash => ruby.hash_new().as_value(),
             }
-            ParserResultType::Hash => {
-                let hash: RHash = ruby.hash_new();
-                for (name, values) in batch.columns {
-                    let col_array: RArray = ruby.ary_new_capa(values.len());
-                    for value in values {
-                        let ruby_value = parquet_to_ruby(value).map_err(|e| {
-                            MagnusError::new(ruby.exception_runtime_error(), e.to_string())
-                        })?;
-                        col_array.push(ruby_value)?;
+        } else {
+            match args.result_type {
+                ParserResultType::Array => {
+                    let array: RArray = ruby.ary_new_capa(batch.columns.len());
+                    for (_name, values) in batch.columns {
+                        let col_array: RArray = ruby.ary_new_capa(values.len());
+                        for value in values {
+                            let ruby_value = parquet_to_ruby(value).map_err(|e| {
+                                MagnusError::new(ruby.exception_runtime_error(), e.to_string())
+                            })?;
+                            col_array.push(ruby_value)?;
+                        }
+                        array.push(col_array)?;
                     }
-                    hash.aset(name, col_array)?;
+                    array.as_value()
                 }
-                hash.as_value()
+                ParserResultType::Hash => {
+                    let hash: RHash = ruby.hash_new();
+                    for (name, values) in batch.columns {
+                        let col_array: RArray = ruby.ary_new_capa(values.len());
+                        for value in values {
+                            let ruby_value = parquet_to_ruby(value).map_err(|e| {
+                                MagnusError::new(ruby.exception_runtime_error(), e.to_string())
+                            })?;
+                            col_array.push(ruby_value)?;
+                        }
+                        hash.aset(name, col_array)?;
+                    }
+                    hash.as_value()
+                }
             }
         };
 

--- a/ext/parquet-ruby-adapter/src/remote.rs
+++ b/ext/parquet-ruby-adapter/src/remote.rs
@@ -1,0 +1,208 @@
+//! Remote data source support for range-based Parquet reads
+
+use bytes::Bytes;
+use magnus::value::{Opaque, ReprValue};
+use magnus::{Error as MagnusError, RString, Ruby, Value};
+use std::error::Error;
+use std::fmt;
+use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult, Seek, SeekFrom};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteError(String);
+
+impl fmt::Display for RemoteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for RemoteError {}
+
+/// Expected Ruby side API for remote sources
+///
+/// ```ruby
+/// class MySource
+///   def byte_length
+///     # => Integer
+///   end
+///
+///   def read_range(offset, length)
+///     # => binary String containing requested bytes
+///   end
+/// end
+/// ```
+pub(crate) struct RemoteSource {
+    inner: Opaque<Value>,
+}
+
+impl RemoteSource {
+    pub fn new(value: Value) -> Result<Self, MagnusError> {
+        if !value.respond_to("read_range", false)? {
+            return Err(MagnusError::new(
+                magnus::exception::arg_error(),
+                "Remote source must respond to #read_range(offset, length)",
+            ));
+        }
+
+        if !value.respond_to("byte_length", false)? {
+            return Err(MagnusError::new(
+                magnus::exception::arg_error(),
+                "Remote source must respond to #byte_length",
+            ));
+        }
+
+        Ok(Self {
+            inner: Opaque::from(value),
+        })
+    }
+
+    fn with_inner<T, F>(&self, func: F) -> Result<T, MagnusError>
+    where
+        F: FnOnce(&Ruby, Value) -> Result<T, MagnusError>,
+    {
+        let ruby = Ruby::get().map_err(|_| {
+            MagnusError::new(
+                magnus::exception::runtime_error(),
+                "Failed to get Ruby runtime",
+            )
+        })?;
+        let value = ruby.get_inner(self.inner);
+        func(&ruby, value)
+    }
+
+    pub fn len(&self) -> Result<u64, MagnusError> {
+        self.with_inner(|_ruby, value| {
+            let length: i64 = value.funcall("byte_length", ())?;
+            if length < 0 {
+                Err(MagnusError::new(
+                    magnus::exception::range_error(),
+                    "Remote source reported negative byte_length",
+                ))
+            } else {
+                Ok(length as u64)
+            }
+        })
+    }
+
+    pub fn read_range(&self, offset: u64, length: usize) -> Result<Bytes, MagnusError> {
+        if length == 0 {
+            return Ok(Bytes::new());
+        }
+
+        self.with_inner(|_ruby, value| {
+            let string: RString = value.funcall("read_range", (offset, length))?;
+            let slice = unsafe { string.as_slice().to_vec() };
+            Ok(Bytes::from(slice))
+        })
+    }
+}
+
+/// Thread-safe wrapper around the remote source
+#[derive(Clone)]
+pub(crate) struct ThreadSafeRemoteSource(Arc<Mutex<RemoteSource>>);
+
+impl ThreadSafeRemoteSource {
+    pub(crate) fn new(source: RemoteSource) -> Self {
+        Self(Arc::new(Mutex::new(source)))
+    }
+
+    pub(crate) fn len(&self) -> Result<u64, RemoteError> {
+        let guard = self
+            .0
+            .lock()
+            .map_err(|e| RemoteError(format!("Remote source lock poisoned: {}", e)))?;
+        guard.len().map_err(|e| RemoteError(e.to_string()))
+    }
+
+    pub(crate) fn read_range(&self, offset: u64, length: usize) -> Result<Bytes, RemoteError> {
+        let guard = self
+            .0
+            .lock()
+            .map_err(|e| RemoteError(format!("Remote source lock poisoned: {}", e)))?;
+        guard
+            .read_range(offset, length)
+            .map_err(|e| RemoteError(e.to_string()))
+    }
+}
+
+/// Reader that serves a specific byte range using repeated remote fetches
+pub(crate) struct RemoteRangeReader {
+    source: ThreadSafeRemoteSource,
+    start: u64,
+    end: u64,
+    pos: u64,
+}
+
+impl RemoteRangeReader {
+    pub fn new(source: ThreadSafeRemoteSource, start: u64, length: u64) -> Self {
+        Self {
+            source,
+            start,
+            end: start + length,
+            pos: start,
+        }
+    }
+}
+
+impl Read for RemoteRangeReader {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        let remaining = (self.end - self.pos) as usize;
+        if remaining == 0 {
+            return Ok(0);
+        }
+
+        let to_read = buf.len().min(remaining);
+        let bytes = self
+            .source
+            .read_range(self.pos, to_read)
+            .map_err(|e| IoError::new(ErrorKind::Other, e))?;
+
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+
+        let len = bytes.len().min(buf.len());
+        buf[..len].copy_from_slice(&bytes[..len]);
+        self.pos += len as u64;
+        Ok(len)
+    }
+}
+
+impl Seek for RemoteRangeReader {
+    fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(offset) => self.start + offset,
+            SeekFrom::Current(delta) => {
+                let signed = self.pos as i64 + delta;
+                if signed < self.start as i64 {
+                    return Err(IoError::new(
+                        ErrorKind::InvalidInput,
+                        "Attempted to seek before start of range",
+                    ));
+                }
+                signed as u64
+            }
+            SeekFrom::End(delta) => {
+                let signed = self.end as i64 + delta;
+                if signed < self.start as i64 {
+                    return Err(IoError::new(
+                        ErrorKind::InvalidInput,
+                        "Attempted to seek before start of range",
+                    ));
+                }
+                signed as u64
+            }
+        };
+
+        if new_pos > self.end {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "Attempted to seek beyond end of range",
+            ));
+        }
+
+        self.pos = new_pos;
+        Ok(self.pos - self.start)
+    }
+}

--- a/ext/parquet-ruby-adapter/src/types.rs
+++ b/ext/parquet-ruby-adapter/src/types.rs
@@ -23,6 +23,7 @@ pub struct RowEnumeratorArgs {
     pub to_read: Value,
     pub result_type: ParserResultType,
     pub columns: Option<Vec<String>>,
+    pub row_groups: Option<Vec<usize>>,
     pub strict: bool,
     pub logger: Option<Value>,
 }
@@ -34,6 +35,7 @@ pub struct ColumnEnumeratorArgs {
     pub result_type: ParserResultType,
     pub columns: Option<Vec<String>>,
     pub batch_size: Option<usize>,
+    pub row_groups: Option<Vec<usize>>,
     pub strict: bool,
     pub logger: Option<Value>,
 }

--- a/ext/parquet-ruby-adapter/src/utils.rs
+++ b/ext/parquet-ruby-adapter/src/utils.rs
@@ -188,8 +188,8 @@ pub fn create_column_enumerator(
     if let Some(columns) = args.columns {
         kwargs.aset(Symbol::new("columns"), RArray::from_vec(columns))?;
     }
-    if let Some(batch_size) = args.batch_size {
-        kwargs.aset(Symbol::new("batch_size"), batch_size)?;
+    if let Some(row_groups) = args.row_groups {
+        kwargs.aset(Symbol::new("row_groups"), RArray::from_vec(row_groups))?;
     }
     if args.strict {
         kwargs.aset(Symbol::new("strict"), true)?;

--- a/ext/parquet/src/adapter_ffi.rs
+++ b/ext/parquet/src/adapter_ffi.rs
@@ -4,6 +4,7 @@ use parquet_ruby_adapter::utils::parse_string_or_symbol;
 use parquet_ruby_adapter::{
     logger::RubyLogger, types::ParserResultType, utils::parse_parquet_write_args,
 };
+
 pub fn each_row(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError> {
     let ruby = Ruby::get().map_err(|_| {
         MagnusError::new(
@@ -23,6 +24,7 @@ pub fn each_row(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError> {
         (
             Option<Option<Value>>,       // result_type
             Option<Option<Vec<String>>>, // columns
+            Option<Option<Vec<usize>>>,  // row_groups
             Option<Option<bool>>,        // strict
             Option<Option<Value>>,       // logger
         ),
@@ -30,7 +32,7 @@ pub fn each_row(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError> {
     >(
         parsed_args.keywords,
         &[],
-        &["result_type", "columns", "strict", "logger"],
+        &["result_type", "columns", "row_groups", "strict", "logger"],
     )?;
 
     let result_type: ParserResultType = if let Some(rt_value) = kwargs.optional.0.flatten() {
@@ -46,8 +48,9 @@ pub fn each_row(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError> {
         ParserResultType::Hash
     };
     let columns = kwargs.optional.1.flatten();
-    let strict = kwargs.optional.2.flatten().unwrap_or(true);
-    let logger = RubyLogger::new(kwargs.optional.3.flatten())?;
+    let row_groups = kwargs.optional.2.flatten();
+    let strict = kwargs.optional.3.flatten().unwrap_or(true);
+    let logger = RubyLogger::new(kwargs.optional.4.flatten())?;
 
     // Delegate to parquet_ruby_adapter
     parquet_ruby_adapter::reader::each_row(
@@ -56,6 +59,7 @@ pub fn each_row(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError> {
         to_read,
         result_type,
         columns,
+        row_groups,
         strict,
         logger,
     )
@@ -80,6 +84,7 @@ pub fn each_column(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError>
         (
             Option<Option<Value>>,       // result_type
             Option<Option<Vec<String>>>, // columns
+            Option<Option<Vec<usize>>>,  // row_groups
             Option<Option<usize>>,       // batch_size
             Option<Option<bool>>,        // strict
             Option<Option<Value>>,       // logger
@@ -88,7 +93,14 @@ pub fn each_column(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError>
     >(
         parsed_args.keywords,
         &[],
-        &["result_type", "columns", "batch_size", "strict", "logger"],
+        &[
+            "result_type",
+            "columns",
+            "row_groups",
+            "batch_size",
+            "strict",
+            "logger",
+        ],
     )?;
 
     let result_type: ParserResultType = if let Some(rt_value) = kwargs.optional.0.flatten() {
@@ -104,7 +116,8 @@ pub fn each_column(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError>
         ParserResultType::Hash
     };
     let columns = kwargs.optional.1.flatten();
-    let batch_size = if let Some(bs) = kwargs.optional.2.flatten() {
+    let row_groups = kwargs.optional.2.flatten();
+    let batch_size = if let Some(bs) = kwargs.optional.3.flatten() {
         if bs == 0 {
             return Err(MagnusError::new(
                 magnus::exception::arg_error(),
@@ -115,8 +128,8 @@ pub fn each_column(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError>
     } else {
         None
     };
-    let strict = kwargs.optional.3.flatten().unwrap_or(true);
-    let logger = RubyLogger::new(kwargs.optional.4.flatten())?;
+    let strict = kwargs.optional.4.flatten().unwrap_or(true);
+    let logger = RubyLogger::new(kwargs.optional.5.flatten())?;
 
     // Delegate to parquet_ruby_adapter
     parquet_ruby_adapter::reader::each_column(
@@ -126,6 +139,7 @@ pub fn each_column(rb_self: Value, args: &[Value]) -> Result<Value, MagnusError>
         result_type,
         columns,
         batch_size,
+        row_groups,
         strict,
         logger,
     )

--- a/lib/parquet.rb
+++ b/lib/parquet.rb
@@ -8,4 +8,26 @@ rescue LoadError
 end
 
 module Parquet
+  class << self
+    alias_method :__original_each_row__, :each_row
+    alias_method :__original_each_column__, :each_column
+
+    def each_row(source, result_type: :hash, columns: nil, row_groups: nil, strict: false, logger: nil, &block)
+      return enum_for(:each_row, source, result_type: result_type, columns: columns, row_groups: row_groups, strict: strict, logger: logger) unless block_given?
+
+      columns = Array(columns).map!(&:to_s) if columns
+      row_groups = Array(row_groups).map!(&:to_i) if row_groups
+
+      __original_each_row__(source, result_type: result_type, columns: columns, row_groups: row_groups, strict: strict, logger: logger, &block)
+    end
+
+    def each_column(source, result_type: :hash, columns: nil, row_groups: nil, batch_size: nil, strict: false, logger: nil, &block)
+      return enum_for(:each_column, source, result_type: result_type, columns: columns, row_groups: row_groups, batch_size: batch_size, strict: strict, logger: logger) unless block_given?
+
+      columns = Array(columns).map!(&:to_s) if columns
+      row_groups = Array(row_groups).map!(&:to_i) if row_groups
+
+      __original_each_column__(source, result_type: result_type, columns: columns, row_groups: row_groups, batch_size: batch_size, strict: strict, logger: logger, &block)
+    end
+  end
 end

--- a/lib/parquet.rbi
+++ b/lib/parquet.rbi
@@ -133,4 +133,52 @@ module Parquet
   end
   def self.write_columns(read_from, schema:, write_to:, flush_threshold: nil, compression: nil)
   end
+
+  sig do
+    params(
+      source: T.any(String, File, StringIO, IO),
+      result_type: T.nilable(T.any(String, Symbol)),
+      columns: T.nilable(T::Array[String]),
+      row_groups: T.nilable(T::Array[Integer]),
+      strict: T.nilable(T::Boolean),
+      logger: T.nilable(T.untyped)
+    ).returns(T::Enumerator[T.any(T::Hash[String, T.untyped], T::Array[T.untyped])])
+  end
+  sig do
+    params(
+      source: T.any(String, File, StringIO, IO),
+      result_type: T.nilable(T.any(String, Symbol)),
+      columns: T.nilable(T::Array[String]),
+      row_groups: T.nilable(T::Array[Integer]),
+      strict: T.nilable(T::Boolean),
+      logger: T.nilable(T.untyped),
+      blk: T.nilable(T.proc.params(row: T.any(T::Hash[String, T.untyped], T::Array[T.untyped])).void)
+    ).returns(NilClass)
+  end
+  def self.each_row(source, result_type: nil, columns: nil, row_groups: nil, strict: nil, logger: nil, &blk); end
+
+  sig do
+    params(
+      source: T.any(String, File, StringIO, IO),
+      result_type: T.nilable(T.any(String, Symbol)),
+      columns: T.nilable(T::Array[String]),
+      row_groups: T.nilable(T::Array[Integer]),
+      batch_size: T.nilable(Integer),
+      strict: T.nilable(T::Boolean),
+      logger: T.nilable(T.untyped)
+    ).returns(T::Enumerator[T.any(T::Hash[String, T::Array[T.untyped]], T::Array[T::Array[T.untyped]])])
+  end
+  sig do
+    params(
+      source: T.any(String, File, StringIO, IO),
+      result_type: T.nilable(T.any(String, Symbol)),
+      columns: T.nilable(T::Array[String]),
+      row_groups: T.nilable(T::Array[Integer]),
+      batch_size: T.nilable(Integer),
+      strict: T.nilable(T::Boolean),
+      logger: T.nilable(T.untyped),
+      blk: T.nilable(T.proc.params(batch: T.any(T::Hash[String, T::Array[T.untyped]], T::Array[T::Array[T.untyped]])).void)
+    ).returns(NilClass)
+  end
+  def self.each_column(source, result_type: nil, columns: nil, row_groups: nil, batch_size: nil, strict: nil, logger: nil, &blk); end
 end

--- a/test/column_test.rb
+++ b/test/column_test.rb
@@ -55,6 +55,10 @@ class ColumnTest < Minitest::Test
     assert_kind_of Hash, batches.first
     assert_equal batches.first.keys.sort, %w[id].sort # Only id column
     assert_equal [1, 2, 3], batches.first["id"]
+
+    # row_groups: on small single-row-group files it should be equivalent
+    first_batch_rg = Parquet.each_column("test/data.parquet", columns: ["id"], row_groups: [0], result_type: :hash).first
+    assert_equal ["id"], first_batch_rg.keys.sort
   end
 
   def test_each_column_empty_file

--- a/test/enumerator_test.rb
+++ b/test/enumerator_test.rb
@@ -9,6 +9,36 @@ class EnumeratorTest < Minitest::Test
     File.delete(@test_file) if File.exist?(@test_file)
   end
 
+  def test_remote_source_integration
+    # Create test data
+    data = [
+      ["A", 1],
+      ["B", 2],
+      ["C", 3]
+    ]
+    schema = {
+      fields: [
+        { name: 'letter', type: :string },
+        { name: 'number', type: :int32 }
+      ]
+    }
+
+    Parquet.write_rows(data, schema: schema, write_to: @test_file)
+
+    # Simple remote wrapper that slices the file bytes
+    file_bytes = File.binread(@test_file)
+    remote = Class.new do
+      define_method(:initialize) { |bytes| @bytes = bytes }
+      define_method(:byte_length) { @bytes.bytesize }
+      define_method(:read_range) { |offset, length| @bytes.byteslice(offset, length) || ''.b }
+    end.new(file_bytes)
+
+    rows = Parquet.each_row(remote, columns: ['letter', 'number']).to_a
+    assert_equal 3, rows.length
+    assert_equal 'A', rows[0]['letter']
+    assert_equal 1, rows[0]['number']
+  end
+
   def test_each_row_returns_enumerator_without_block
     # Create test data
     data = [
@@ -16,7 +46,7 @@ class EnumeratorTest < Minitest::Test
       ["Bob", 25, "Designer"],
       ["Charlie", 35, "Manager"]
     ]
-    
+
     schema = {
       fields: [
         {name: 'name', type: :string},
@@ -24,36 +54,36 @@ class EnumeratorTest < Minitest::Test
         {name: 'role', type: :string}
       ]
     }
-    
+
     # Write data
     Parquet.write_rows(data, schema: schema, write_to: @test_file)
-    
+
     # Get enumerator
     enum = Parquet.each_row(@test_file)
-    
+
     # Verify it's an Enumerator
     assert_kind_of Enumerator, enum
-    
+
     # Test various enumerator methods
     rows = enum.to_a
     assert_equal 3, rows.length
     assert_equal "Alice", rows[0]['name']
-    
+
     # Test lazy evaluation with take
     first_two = Parquet.each_row(@test_file).take(2)
     assert_equal 2, first_two.length
     assert_equal "Bob", first_two[1]['name']
-    
+
     # Test with select
     adults = Parquet.each_row(@test_file).select { |row| row['age'] >= 30 }
     assert_equal 2, adults.length
     assert_equal ["Alice", "Charlie"], adults.map { |r| r['name'] }
-    
+
     # Test map
     names = Parquet.each_row(@test_file).map { |row| row['name'] }
     assert_equal ["Alice", "Bob", "Charlie"], names
   end
-  
+
   def test_each_column_returns_enumerator_without_block
     # Create test data
     data = [
@@ -62,7 +92,7 @@ class EnumeratorTest < Minitest::Test
       ["Charlie", 35, true],
       ["David", 28, false]
     ]
-    
+
     schema = {
       fields: [
         {name: 'name', type: :string},
@@ -70,33 +100,33 @@ class EnumeratorTest < Minitest::Test
         {name: 'active', type: :boolean}
       ]
     }
-    
+
     # Write data
     Parquet.write_rows(data, schema: schema, write_to: @test_file)
-    
+
     # Get enumerator
     enum = Parquet.each_column(@test_file, batch_size: 2)
-    
+
     # Verify it's an Enumerator
     assert_kind_of Enumerator, enum
-    
+
     # Test iteration
     batches = enum.to_a
     assert batches.length > 0
-    
+
     # First batch should have data
     first_batch = batches.first
     assert_equal ['active', 'age', 'name'], first_batch.keys.sort
-    
+
     # Test with first
     first_batch_again = Parquet.each_column(@test_file, batch_size: 2).first
     assert_equal first_batch, first_batch_again
-    
+
     # Test lazy evaluation with take
     first_two_batches = Parquet.each_column(@test_file, batch_size: 1).take(2)
     assert_equal 2, first_two_batches.length
   end
-  
+
   def test_enumerator_with_options
     # Create test data
     data = [
@@ -104,7 +134,7 @@ class EnumeratorTest < Minitest::Test
       ["Bob", 25, "Designer", 45000],
       ["Charlie", 35, "Manager", 60000]
     ]
-    
+
     schema = {
       fields: [
         {name: 'name', type: :string},
@@ -113,29 +143,33 @@ class EnumeratorTest < Minitest::Test
         {name: 'salary', type: :int32}
       ]
     }
-    
+
     # Write data
     Parquet.write_rows(data, schema: schema, write_to: @test_file)
-    
+
     # Test with columns option
     enum = Parquet.each_row(@test_file, columns: ['name', 'salary'])
     rows = enum.to_a
     assert_equal 3, rows.length
     assert_equal ['name', 'salary'], rows[0].keys.sort
     assert_nil rows[0]['age']  # Column not selected
-    
+
     # Test with result_type array
     enum_array = Parquet.each_row(@test_file, result_type: 'array')
     arrays = enum_array.to_a
     assert_equal 3, arrays.length
     assert_kind_of Array, arrays[0]
     assert_equal 4, arrays[0].length  # All columns
+
+    # Test row_groups option behaves like full read on single-RG files
+    rows_rg = Parquet.each_row(@test_file, columns: ['name'], row_groups: [0]).to_a
+    assert_equal rows.map { |r| r['name'] }, rows_rg.map { |r| r['name'] }
   end
-  
+
   def test_enumerator_chaining
     # Create test data with more rows
     data = (1..10).map { |i| ["Person#{i}", 20 + i, i * 1000] }
-    
+
     schema = {
       fields: [
         {name: 'name', type: :string},
@@ -143,39 +177,39 @@ class EnumeratorTest < Minitest::Test
         {name: 'score', type: :int32}
       ]
     }
-    
+
     # Write data
     Parquet.write_rows(data, schema: schema, write_to: @test_file)
-    
+
     # Test complex chaining
     result = Parquet.each_row(@test_file)
       .select { |row| row['age'] > 25 }
       .map { |row| { name: row['name'], score_doubled: row['score'] * 2 } }
       .take(3)
-    
+
     assert_equal 3, result.length
     assert_equal "Person6", result[0][:name]
     assert_equal 12000, result[0][:score_doubled]
   end
-  
+
   def test_enumerator_with_each_entry
     # Create test data
     data = [["A", 1], ["B", 2], ["C", 3]]
-    
+
     schema = {
       fields: [
         {name: 'letter', type: :string},
         {name: 'number', type: :int32}
       ]
     }
-    
+
     # Write data
     Parquet.write_rows(data, schema: schema, write_to: @test_file)
-    
+
     # Test each.with_index
     enum = Parquet.each_row(@test_file)
     indexed = enum.each.with_index.to_a
-    
+
     assert_equal 3, indexed.length
     assert_equal ["A", 0], [indexed[0][0]['letter'], indexed[0][1]]
     assert_equal ["B", 1], [indexed[1][0]['letter'], indexed[1][1]]


### PR DESCRIPTION
This adds first‑class support for reading Parquet from remote/random‑access sources (for example, AWS S3 or any HTTP Range endpoint) without downloading entire files, and it introduces explicit row‑group selection and pruning to minimize bytes fetched. The Ruby API remains familiar; internally we add a `RemoteSource` path and extend the core reader to accept row‑group filters alongside column projection so callers can target only the data they need.

### Understanding of the problem
- The reader effectively assumes local files or in‑memory bytes, which makes S3 and other object stores inefficient for Range‑based lookups because you either fall back to whole‑file downloads or ad‑hoc buffering, and you cannot consistently benefit from row‑group pruning.
- The API does not offer a simple, direct way to prune row groups at read time even when the footer statistics can cheaply identify which groups contain the target rows.

### Solution
- Remote source contract (Ruby): Any object that implements `byte_length -> Integer` and `read_range(offset, length) -> binary String` can now be passed anywhere a path or IO was accepted, which enables true random‑access reads and unlocks pruning only the row groups you need.
- Adapter integration (Rust): `RemoteSource` validates the Ruby object; `ThreadSafeRemoteSource` synchronizes concurrent calls; `RemoteRangeReader` implements `Read + Seek` over repeated `read_range` calls with exact‑length guarantees; and `CloneableChunkReader` gains a `Remote` variant with `from_remote` factory.
- Row‑group selection: `row_groups: [Integer, ...]` is now supported on `Parquet.each_row` and `Parquet.each_column`, and the core reader provides `read_rows_with_selection` / `read_columns_with_selection` to combine row‑group filters with column projection.
- Metadata statistics exposure: Row‑group level stats (e.g., `min_bytes`, `max_bytes`, `null_count`) are returned to Ruby so callers can prune candidates before any large reads.
- Ruby ergonomics: `lib/parquet.rb` coerces `columns` to `String[]` and `row_groups` to `Integer[]` while preserving enumerator behavior; all new features are opt‑in and backwards compatible.

### Example: AWS S3 remote source

```ruby
class S3RangeSource
  def initialize(bucket:, key:, s3: Aws::S3::Client.new, size: nil)
    @bucket, @key, @s3, @size = bucket, key, s3, size
  end

  def byte_length
    @size ||= @s3.head_object(bucket: @bucket, key: @key).content_length
  end

  def read_range(offset, length)
    return "".b if length == 0
    resp = @s3.get_object(bucket: @bucket, key: @key, range: "bytes=#{offset}-#{offset + length - 1}")
    data = +""
    resp.body.read(nil, out: data)
    data
  end
end
```

Case A: you already know the row group ordinal (from a catalog)
```ruby
source = S3RangeSource.new(bucket: "my-bucket", key: "path/to/file.parquet")
rows = Parquet.each_row(
  source,
  columns: %w[id output],
  row_groups: [rg_ordinal],
  strict: false
).to_a
```

Case B: you don’t have a catalog; pick candidates via footer stats (id example)
```ruby
source   = S3RangeSource.new(bucket: "my-bucket", key: "path/to/file.parquet")
metadata = Parquet.metadata(source)

fields   = metadata.dig("schema", "fields") || []
id_idx   = fields.each_with_index.find { |f, _| f["name"] == "id" }&.last
rgs      = metadata["row_groups"] || []

target_id = 123
candidates =
  if id_idx
    rgs.filter_map do |rg|
      s = (rg["statistics"] || {})[id_idx]
      next unless s && s["min_bytes"] && s["max_bytes"]
      min_v = s["min_bytes"].byteslice(0, 8).unpack1("q<") rescue nil
      max_v = s["max_bytes"].byteslice(0, 8).unpack1("q<") rescue nil
      (min_v && max_v && (min_v..max_v).cover?(target_id)) ? rg["ordinal"] : nil
    end
  else
    []
  end
candidates = rgs.map { |rg| rg["ordinal"] } if candidates.empty?

rows = Parquet.each_row(
  source,
  columns: %w[id output],
  row_groups: candidates,
  strict: false
).to_a
```

Notes:
- This only fetches the footer plus the selected row group(s), not the whole file.
- If you have a catalog of row-group ordinals (or offsets), you can use Case A for fewer footer reads and simpler logic.

### Performance characteristics
- Range‑based reads mean the reader fetches only the footer and the selected row‑group spans rather than the whole file.
- Combining column projection with row‑group pruning materially reduces bytes transferred and tail latency for point lookups and filter‑heavy scans.

### Tests
- `test/enumerator_test.rb`: adds `test_remote_source_integration` and a `row_groups` smoke check.
- `test/column_test.rb`: adds a `row_groups` smoke check for column batches.
- Existing enumerator and schema tests also exercise the updated paths.

### Backwards compatibility
- Existing file and IO sources continue to work exactly as before.
- Remote reads and row‑group selection are opt‑in and require no changes for current users.
