### PR TITLE
Support Ruby 4.0 by upgrading magnus to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,21 +836,21 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d87ae53030f3a22e83879e666cb94e58a7bdf31706878a0ba48752994146dab"
+checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
 dependencies = [
  "magnus-macros",
  "rb-sys",
- "rb-sys-env 0.1.2",
+ "rb-sys-env",
  "seq-macro",
 ]
 
 [[package]]
 name = "magnus-macros"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
+checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,7 +1017,7 @@ dependencies = [
  "parquet-ruby-adapter",
  "rand",
  "rb-sys",
- "rb-sys-env 0.2.2",
+ "rb-sys-env",
  "simdutf8",
  "tempfile",
  "thiserror",
@@ -1093,7 +1093,7 @@ dependencies = [
  "parquet 55.2.0",
  "parquet-core",
  "rb-sys",
- "rb-sys-env 0.2.2",
+ "rb-sys-env",
  "tempfile",
  "thiserror",
  "uuid",
@@ -1190,18 +1190,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.116"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059846f68396df83155779c75336ca24567741cb95256e6308c9fcc370e8dad"
+checksum = "c85c4188462601e2aa1469def389c17228566f82ea72f137ed096f21591bc489"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.116"
+version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac217510df41b9ffc041573e68d7a02aaff770c49943c7494441c4b224b0ecd0"
+checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -1211,12 +1211,6 @@ dependencies = [
  "shell-words",
  "syn",
 ]
-
-[[package]]
-name = "rb-sys-env"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
 
 [[package]]
 name = "rb-sys-env"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     bigdecimal (3.1.5)
     csv (3.3.2)
     memory_profiler (1.1.0)
-    minitest (5.25.4)
+    minitest (5.27.0)
     rake (13.2.1)
     rake-compiler (1.2.9)
       rake

--- a/ext/parquet-ruby-adapter/Cargo.toml
+++ b/ext/parquet-ruby-adapter/Cargo.toml
@@ -11,7 +11,7 @@ arrow-array = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_0
 arrow-buffer = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader" }
 arrow-schema = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader" }
 bytes = "1.5"
-magnus = { version = "0.7", features = ["rb-sys"] }
+magnus = { version = "0.8", features = ["rb-sys", "old-api"] }
 num = "0.4.3"
 ordered-float = "5.0.0"
 parquet = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader", features = ["arrow"] }

--- a/ext/parquet-ruby-adapter/Cargo.toml
+++ b/ext/parquet-ruby-adapter/Cargo.toml
@@ -11,7 +11,7 @@ arrow-array = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_0
 arrow-buffer = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader" }
 arrow-schema = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader" }
 bytes = "1.5"
-magnus = { version = "0.8", features = ["rb-sys", "old-api"] }
+magnus = { version = "0.8", features = ["rb-sys"] }
 num = "0.4.3"
 ordered-float = "5.0.0"
 parquet = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader", features = ["arrow"] }

--- a/ext/parquet-ruby-adapter/src/string_cache.rs
+++ b/ext/parquet-ruby-adapter/src/string_cache.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::{Arc, LazyLock, Mutex};
 
-use magnus::RString;
+static STRING_CACHE: LazyLock<Mutex<HashSet<Arc<str>>>> =
+    LazyLock::new(|| Mutex::new(HashSet::with_capacity(100)));
 
-static STRING_CACHE: LazyLock<Mutex<HashMap<String, &'static str>>> =
-    LazyLock::new(|| Mutex::new(HashMap::with_capacity(100)));
-
-/// A cache for interning strings in the Ruby VM to reduce memory usage
+/// A cache for interning strings to reduce memory usage
 /// when there are many repeated strings
 #[derive(Debug)]
 pub struct StringCache {
@@ -25,41 +23,37 @@ impl StringCache {
         }
     }
 
-    /// Intern a string in Ruby's VM, returning the same string for tracking
-    /// Note: We return the input string to maintain API compatibility,
-    /// but internally we ensure it's interned in Ruby's VM
+    /// Intern a string, returning a shared reference.
+    /// Deduplicates repeated strings via an internal cache.
     pub fn intern(&mut self, s: String) -> Arc<str> {
         if !self.enabled {
             return Arc::from(s.as_str());
         }
 
-        // Try to get or create the interned string
-        let result = (|| -> Result<(), String> {
+        let result = (|| -> Result<Arc<str>, String> {
             let mut cache = STRING_CACHE.lock().map_err(|e| e.to_string())?;
 
-            if cache.contains_key(s.as_str()) {
+            if let Some(cached) = cache.get(s.as_str()) {
                 let mut hits = self.hits.lock().map_err(|e| e.to_string())?;
                 *hits += 1;
+                Ok(Arc::clone(cached))
             } else {
-                // Create Ruby string and intern it
-                let rstring = RString::new(&s);
-                let interned = rstring.to_interned_str();
-                let static_str = interned.as_str().map_err(|e| e.to_string())?;
-
-                cache.insert(s.clone(), static_str);
+                let arc: Arc<str> = Arc::from(s.as_str());
+                cache.insert(Arc::clone(&arc));
 
                 let mut misses = self.misses.lock().map_err(|e| e.to_string())?;
                 *misses += 1;
+                Ok(arc)
             }
-            Ok(())
         })();
 
-        // Log any errors but don't fail - just return the string
-        if let Err(e) = result {
-            eprintln!("String cache error: {}", e);
+        match result {
+            Ok(arc) => arc,
+            Err(e) => {
+                eprintln!("String cache error: {}", e);
+                Arc::from(s.as_str())
+            }
         }
-
-        Arc::from(s.as_str())
     }
 
     /// Get cache statistics

--- a/ext/parquet-ruby-adapter/src/string_cache.rs
+++ b/ext/parquet-ruby-adapter/src/string_cache.rs
@@ -1,10 +1,12 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 
-static STRING_CACHE: LazyLock<Mutex<HashSet<Arc<str>>>> =
-    LazyLock::new(|| Mutex::new(HashSet::with_capacity(100)));
+use magnus::RString;
 
-/// A cache for interning strings to reduce memory usage
+static STRING_CACHE: LazyLock<Mutex<HashMap<String, &'static str>>> =
+    LazyLock::new(|| Mutex::new(HashMap::with_capacity(100)));
+
+/// A cache for interning strings in the Ruby VM to reduce memory usage
 /// when there are many repeated strings
 #[derive(Debug)]
 pub struct StringCache {
@@ -23,37 +25,46 @@ impl StringCache {
         }
     }
 
-    /// Intern a string, returning a shared reference.
-    /// Deduplicates repeated strings via an internal cache.
+    /// Intern a string in Ruby's VM, returning the same string for tracking
+    /// Note: We return the input string to maintain API compatibility,
+    /// but internally we ensure it's interned in Ruby's VM
     pub fn intern(&mut self, s: String) -> Arc<str> {
         if !self.enabled {
             return Arc::from(s.as_str());
         }
 
-        let result = (|| -> Result<Arc<str>, String> {
+        // Try to get or create the interned string
+        let result = (|| -> Result<(), String> {
             let mut cache = STRING_CACHE.lock().map_err(|e| e.to_string())?;
 
-            if let Some(cached) = cache.get(s.as_str()) {
+            if cache.contains_key(s.as_str()) {
                 let mut hits = self.hits.lock().map_err(|e| e.to_string())?;
                 *hits += 1;
-                Ok(Arc::clone(cached))
             } else {
-                let arc: Arc<str> = Arc::from(s.as_str());
-                cache.insert(Arc::clone(&arc));
+                // Create Ruby string and intern it
+                let rstring = RString::new(&s);
+                let interned = rstring.to_interned_str();
+                // SAFETY: `to_interned_str` returns a frozen, VM-interned string that
+                // Ruby guarantees will not be garbage collected. The resulting &str is
+                // therefore valid for the lifetime of the process ('static).
+                let static_str: &'static str = unsafe {
+                    std::mem::transmute(interned.as_str().map_err(|e| e.to_string())?)
+                };
+
+                cache.insert(s.clone(), static_str);
 
                 let mut misses = self.misses.lock().map_err(|e| e.to_string())?;
                 *misses += 1;
-                Ok(arc)
             }
+            Ok(())
         })();
 
-        match result {
-            Ok(arc) => arc,
-            Err(e) => {
-                eprintln!("String cache error: {}", e);
-                Arc::from(s.as_str())
-            }
+        // Log any errors but don't fail - just return the string
+        if let Err(e) = result {
+            eprintln!("String cache error: {}", e);
         }
+
+        Arc::from(s.as_str())
     }
 
     /// Get cache statistics

--- a/ext/parquet/Cargo.toml
+++ b/ext/parquet/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "^1.9"
 either = "1.9"
 itertools = "^0.14"
 jiff = "0.2"
-magnus = { version = "0.7", features = ["rb-sys"] }
+magnus = { version = "0.8", features = ["rb-sys", "old-api"] }
 parquet = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader", features = ["json"] }
 parquet-ruby-adapter = { path = "../parquet-ruby-adapter" }
 rand = "0.9"

--- a/ext/parquet/Cargo.toml
+++ b/ext/parquet/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "^1.9"
 either = "1.9"
 itertools = "^0.14"
 jiff = "0.2"
-magnus = { version = "0.8", features = ["rb-sys", "old-api"] }
+magnus = { version = "0.8", features = ["rb-sys"] }
 parquet = { git = "https://github.com/njaremko/arrow-rs", branch = "nathan_06-24-remove_primitive_map_key_assertion_on_record_reader", features = ["json"] }
 parquet-ruby-adapter = { path = "../parquet-ruby-adapter" }
 rand = "0.9"


### PR DESCRIPTION
## Summary

Ruby 4.0 removed the `typed_flag` field from `RTypedData`, which causes compilation failures with magnus 0.7.x:

```
error[E0609]: no field `typed_flag` on type `&rb_sys::RTypedData`
   --> magnus-0.7.1/src/r_typed_data.rs:202:58
```

This PR upgrades magnus from 0.7 to 0.8, which includes the fix (see [matsadler/magnus#147](https://github.com/matsadler/magnus/issues/147)).

### Changes

- **Bump magnus** from `0.7` to `0.8` in both `ext/parquet/Cargo.toml` and `ext/parquet-ruby-adapter/Cargo.toml`
- **Bump rb-sys** from `0.9.116` to `0.9.124` for Ruby 4.0 bindings support
- **Adapt `StringCache`** for magnus 0.8's API: `FString` was removed and `as_str()` is now `unsafe`. Added explicit `unsafe` + `transmute` to restore the `'static` lifetime on interned strings. The interning pattern (`RString::new` → `to_interned_str()` → `as_str()` → cache) is unchanged.

### Notes

- Magnus 0.8 deprecates some associated functions (`RArray::new()`, `Symbol::new()`, `exception::arg_error()`, etc.) in favor of methods on `Ruby`. These generate warnings but compile fine. Left as-is for you to migrate at your convenience.

## Test plan
- [x] `cargo build --release` compiles cleanly on Ruby 4.0.1 (arm64-darwin)
- [ ] Existing test suite passes on Ruby 3.x (backwards compatible — magnus 0.8 supports Ruby 2.6+)
- [ ] Existing test suite passes on Ruby 4.0