### PR TITLE
Fix test_strict_utf8_enforcement regex for magnus 0.8

### DIFF
--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -32,7 +32,7 @@ class ErrorTest < Minitest::Test
           Parquet.write_rows([[invalid_utf8_bytes]].each, schema: schema, write_to: temp_path)
         end
 
-      assert_match(/invalid utf-8 sequence/i, error.message)
+      assert_match(/invalid utf-?8|expected utf-?8/i, error.message)
     ensure
       File.delete(temp_path) if File.exist?(temp_path)
     end


### PR DESCRIPTION
## Summary

`test_strict_utf8_enforcement` has been failing on `main` since #34 (the magnus 0.8 upgrade). The behavior under test is unchanged — invalid UTF-8 still raises `EncodingError` via the writer's encoding-error branch in `ext/parquet-ruby-adapter/src/writer.rs:198-204`. Only the **wording** of magnus's underlying error changed:

- magnus 0.7: `"invalid utf-8 sequence ..."`
- magnus 0.8: `"expected utf-8, got ASCII-8BIT"`

The test's regex was pinned to the old wording, so the assertion fails even though `EncodingError` is correctly raised.

## Fix

Broaden the regex to accept either wording. This pins the test to its **intent** (the error message identifies a UTF-8 problem) rather than to a specific upstream string — making it resilient to future magnus or arrow-rs re-wordings.

```diff
-      assert_match(/invalid utf-8 sequence/i, error.message)
+      assert_match(/invalid utf-?8|expected utf-?8/i, error.message)
```

## Impact

Restores green CI on `main`. No production code changes; test-only.

## Test plan

- [x] Verified the regex matches both wordings:
  - `"expected utf-8, got ASCII-8BIT"` ✓
  - `"invalid utf-8 sequence at byte 0"` ✓
  - (also `utf8` variants without the hyphen, defensively)
- [ ] CI run on this PR confirms `ErrorTest#test_strict_utf8_enforcement` passes and the rest of the suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)