### PR TITLE
Fix memory growth by streaming writes incrementally

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ## Unreleased
+- `Parquet.write_rows` and `Parquet.write_columns` now stream to the destination
+  instead of buffering the entire file in memory. An Enumerator (or any
+  Enumerable) input is consumed in bounded slices (`batch_size` rows at a time
+  for `write_rows`, one batch at a time for `write_columns`) rather than being
+  drained with `to_a` before writing, and completed row groups are flushed to
+  the destination file once `flush_threshold` is exceeded. Peak write memory is
+  now bounded by `batch_size`/`flush_threshold` instead of growing with the
+  total dataset size, and the destination file grows during the write. Inputs
+  that only respond to `to_a` (and plain Arrays) are still materialized as
+  before. When `write_to:` is an IO object, output is staged in a temporary
+  file on disk and copied to the IO at the end (unchanged). Row-group
+  boundaries may differ from previous releases; file contents are unchanged.
+  `flush_threshold: 0` is now rejected (like `batch_size: 0`) instead of being
+  treated as "flush constantly".
 - `string_cache:` on `Parquet.write_rows` now also accepts an Integer to set the cache
   capacity (`true` uses the default, `false` disables); a non-positive, excessive,
   or non-boolean/non-integer value is rejected. Retention is bounded by entry count,
@@ -14,9 +28,9 @@
   bounded by both entry count and retained bytes.
 - Unify write batch sizing: the core writer now owns all batching/flushing (the adapter no
   longer keeps a second, separately-tuned batch manager), and `batch_size:`/`flush_threshold:`/
-  `sample_size:` are forwarded to it. `flush_threshold` now bounds the writer's in-progress
-  (encoded) buffer rather than an estimate of pre-encode row bytes, and its default is 100MB
-  (was 64MB). Per-batch debug log lines are no longer emitted.
+  `sample_size:` are forwarded to it. `flush_threshold` bounds both the raw bytes staged
+  since the last row-group flush and the writer's in-progress (encoded) buffer, and its
+  default is 100MB (was 64MB). Per-batch debug log lines are no longer emitted.
 - Add a `string_storage:` option to `Parquet.each_row`/`each_column` controlling how
   string values become Ruby strings: `:copy` (default, unchanged), `:intern`
   (dedup low-cardinality equal values through a bounded intern cache, then fall

--- a/README.md
+++ b/README.md
@@ -379,16 +379,31 @@ end
 
 ## Memory Management
 
-Control memory usage with flush thresholds:
+Writes are streamed: an Enumerator (or any Enumerable) passed to `write_rows`
+is consumed in bounded slices rather than materialized up front, and completed
+row groups are flushed to the destination while the input is still being
+enumerated. Peak memory is bounded by `batch_size` and `flush_threshold`, not
+by the total dataset size:
 
 ```ruby
 Parquet.write_rows(huge_dataset.each,
   schema: schema,
   write_to: "output.parquet",
-  batch_size: 1000,              # Positive rows before considering flush
-  flush_threshold: 32 * 1024**2  # Flush if batch exceeds 32MB
+  batch_size: 1000,              # Rows buffered per write batch (also the
+                                 # slice size pulled from an Enumerator)
+  flush_threshold: 32 * 1024**2  # Flush a row group to the destination once
+                                 # ~32MB of raw row data is staged (default 100MB)
 )
 ```
+
+`flush_threshold` bounds both the raw bytes staged since the last flush and
+the writer's encoded in-progress buffer, so row groups reach the destination
+incrementally even when compression shrinks the encoded data dramatically.
+`write_columns` flushes the same way after each batch of columns.
+
+When `write_to:` is an IO object instead of a file path, output is staged in a
+temporary file on disk (memory stays bounded) and copied to the IO after the
+write completes, so the IO receives its bytes only at the end.
 
 Write batch and sample sizes are bounded before buffer allocation. Very large
 batch sizes are rejected, and wide schemas have a lower effective batch cap so

--- a/ext/parquet-core/src/arrow_conversion.rs
+++ b/ext/parquet-core/src/arrow_conversion.rs
@@ -637,7 +637,16 @@ fn build_float64_array(values: &[&ParquetValue]) -> Result<ArrayRef> {
 
 /// Build string array
 fn build_string_array(values: &[&ParquetValue]) -> Result<ArrayRef> {
-    let mut builder = StringBuilder::with_capacity(values.len(), 0);
+    // Pre-size the data buffer exactly: growing it by doubling would
+    // transiently hold up to 3x the payload during the final realloc.
+    let data_capacity: usize = values
+        .iter()
+        .map(|value| match value {
+            ParquetValue::String(s) => s.len(),
+            _ => 0,
+        })
+        .sum();
+    let mut builder = StringBuilder::with_capacity(values.len(), data_capacity);
     for value in values {
         match *value {
             ParquetValue::String(s) => builder.append_value(s.as_ref()),
@@ -655,7 +664,15 @@ fn build_string_array(values: &[&ParquetValue]) -> Result<ArrayRef> {
 
 /// Build binary array
 fn build_binary_array(values: &[&ParquetValue]) -> Result<ArrayRef> {
-    let mut builder = BinaryBuilder::with_capacity(values.len(), 0);
+    // Pre-size the data buffer exactly, as in build_string_array.
+    let data_capacity: usize = values
+        .iter()
+        .map(|value| match value {
+            ParquetValue::Bytes(b) => b.len(),
+            _ => 0,
+        })
+        .sum();
+    let mut builder = BinaryBuilder::with_capacity(values.len(), data_capacity);
     for value in values {
         match *value {
             ParquetValue::Bytes(b) => builder.append_value(b.as_ref()),

--- a/ext/parquet-core/src/writer.rs
+++ b/ext/parquet-core/src/writer.rs
@@ -107,6 +107,7 @@ impl WriterBuilder {
             size_samples: Vec::with_capacity(sample_size),
             total_rows_written: 0,
             fixed_batch_size: self.batch_size,
+            raw_bytes_since_flush: 0,
         })
     }
 }
@@ -123,6 +124,11 @@ pub struct Writer<W: std::io::Write> {
     size_samples: Vec<usize>,
     total_rows_written: usize,
     fixed_batch_size: Option<usize>,
+    /// Estimated raw bytes accepted since the last row-group flush. Tracked
+    /// separately from the arrow writer's encoded buffer sizes so
+    /// `memory_threshold` still bounds in-flight data (and streams row groups
+    /// to the destination) when encoding/compression shrinks it dramatically.
+    raw_bytes_since_flush: usize,
 }
 
 impl<W> Writer<W>
@@ -155,6 +161,7 @@ where
             size_samples: Vec::with_capacity(DEFAULT_SAMPLE_SIZE),
             total_rows_written: 0,
             fixed_batch_size: None,
+            raw_bytes_since_flush: 0,
         })
     }
 
@@ -187,18 +194,27 @@ where
             validate_value_against_field(value, field, &format!("row[{}]", idx))?;
         }
 
+        let row_size = self.estimate_row_size(&row)?;
+
         // Sample row size for dynamic batch sizing
         if self.fixed_batch_size.is_none() {
-            self.sample_row_size(&row)?;
+            self.sample_row_size(row_size);
         }
+
+        // Count raw staged bytes toward the flush threshold.
+        self.raw_bytes_since_flush = self.raw_bytes_since_flush.saturating_add(row_size);
 
         for (col_idx, value) in row.into_iter().enumerate() {
             self.buffered_columns[col_idx].push(value);
         }
         self.buffered_row_count += 1;
 
-        // Check if we need to flush
-        if self.buffered_row_count >= self.current_batch_size {
+        // Check if we need to flush: batch full, or raw staged bytes already
+        // past the threshold (bounds in-flight memory when rows are large
+        // relative to the configured batch size).
+        if self.buffered_row_count >= self.current_batch_size
+            || self.raw_bytes_since_flush >= self.memory_threshold
+        {
             self.flush_buffered_rows()?;
         }
 
@@ -206,9 +222,7 @@ where
     }
 
     /// Sample row size for dynamic batch sizing using reservoir sampling
-    fn sample_row_size(&mut self, row: &[ParquetValue]) -> Result<()> {
-        let row_size = self.estimate_row_size(row)?;
-
+    fn sample_row_size(&mut self, row_size: usize) {
         if self.size_samples.len() < self.sample_size {
             self.size_samples.push(row_size);
         } else {
@@ -227,8 +241,6 @@ where
         if self.size_samples.len() >= samples_required {
             self.update_batch_size();
         }
-
-        Ok(())
     }
 
     /// Estimate the memory size of a single row
@@ -393,11 +405,16 @@ where
                 column.reserve(additional_capacity);
             }
 
-            // Check if we need to flush based on memory usage
-            if writer.in_progress_size() >= self.memory_threshold
+            // Check if we need to flush a completed row group to the
+            // destination. Raw staged bytes trip the threshold too: highly
+            // compressible data can sit far below the threshold once encoded,
+            // which would otherwise keep the whole file buffered until close.
+            if self.raw_bytes_since_flush >= self.memory_threshold
+                || writer.in_progress_size() >= self.memory_threshold
                 || writer.memory_size() >= self.memory_threshold
             {
                 writer.flush()?;
+                self.raw_bytes_since_flush = 0;
             }
         } else {
             return Err(ParquetError::Io(std::io::Error::new(
@@ -466,6 +483,7 @@ where
 
         // Sort columns to match schema order and convert to arrays
         let mut arrow_columns = Vec::with_capacity(schema_fields.len());
+        let mut batch_raw_bytes: usize = 0;
 
         for field in schema_fields {
             let values = columns_by_name
@@ -478,6 +496,8 @@ where
                     field,
                     &format!("column '{}'[{}]", field.name(), idx),
                 )?;
+                batch_raw_bytes = batch_raw_bytes
+                    .saturating_add(self.estimate_value_size(value, field.data_type())?);
             }
 
             let array = parquet_values_to_arrow_array(&values, field)?;
@@ -490,6 +510,18 @@ where
         // Write the batch
         if let Some(writer) = &mut self.arrow_writer {
             writer.write(&batch)?;
+            self.raw_bytes_since_flush = self.raw_bytes_since_flush.saturating_add(batch_raw_bytes);
+
+            // Check if we need to flush a completed row group, like the row
+            // path does; otherwise repeated write_columns calls accumulate
+            // every row group in memory until close.
+            if self.raw_bytes_since_flush >= self.memory_threshold
+                || writer.in_progress_size() >= self.memory_threshold
+                || writer.memory_size() >= self.memory_threshold
+            {
+                writer.flush()?;
+                self.raw_bytes_since_flush = 0;
+            }
         } else {
             return Err(ParquetError::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -509,6 +541,7 @@ where
         if let Some(writer) = &mut self.arrow_writer {
             writer.flush()?;
         }
+        self.raw_bytes_since_flush = 0;
         Ok(())
     }
 

--- a/ext/parquet-ruby-adapter/src/utils.rs
+++ b/ext/parquet-ruby-adapter/src/utils.rs
@@ -106,7 +106,14 @@ pub fn parse_parquet_write_args(
             kwargs.optional.0.flatten(),
             MAX_BATCH_SIZE,
         )?,
-        flush_threshold: kwargs.optional.1.flatten(),
+        // A zero threshold would flush a row group per row; reject it like the
+        // other sizing options rather than producing a pathological file.
+        flush_threshold: parse_positive_bounded_usize(
+            ruby,
+            "flush_threshold",
+            kwargs.optional.1.flatten(),
+            usize::MAX,
+        )?,
         compression: kwargs.optional.2.flatten(),
         sample_size: parse_positive_bounded_usize(
             ruby,

--- a/ext/parquet-ruby-adapter/src/writer.rs
+++ b/ext/parquet-ruby-adapter/src/writer.rs
@@ -1,5 +1,5 @@
 use magnus::value::ReprValue;
-use magnus::{Error as MagnusError, Ruby, TryConvert, Value};
+use magnus::{Enumerator, Error as MagnusError, RArray, Ruby, TryConvert, Value};
 use parquet_core::writer::WriterBuilder;
 use parquet_core::Schema;
 use std::io::{BufReader, BufWriter, Write};
@@ -8,6 +8,11 @@ use tempfile::NamedTempFile;
 use crate::io::RubyIOWriter;
 use crate::types::WriterOutput;
 use crate::utils::parse_compression;
+
+/// Rows pulled per slice when streaming rows from an Enumerable without a
+/// user-provided batch_size. Mirrors the core writer's default batch size so
+/// the Ruby-side slice and the core row buffer stay in the same range.
+const DEFAULT_ROW_SLICE_SIZE: usize = 1000;
 
 /// How the writer batches rows before flushing. All batch sizing is owned by the
 /// core `Writer`; the adapter only forwards the user's options.
@@ -125,6 +130,128 @@ fn copy_temp_file_to_io(
     Ok(())
 }
 
+/// The rows to write, either already materialized or pulled lazily from an
+/// Enumerable in bounded slices so the whole input is never resident at once.
+enum RowSource {
+    Materialized(RArray),
+    Streamed {
+        first_slice: Option<RArray>,
+        remaining: Enumerator,
+    },
+}
+
+/// Classify `read_from` without draining it. Arrays are used as-is; anything
+/// else that supports `each_slice` (Enumerator, any Enumerable) is streamed in
+/// bounded slices; objects that only support `to_a` keep the legacy
+/// materialize-first behavior.
+fn row_source(
+    ruby: &Ruby,
+    read_from: Value,
+    batch_size: Option<usize>,
+) -> Result<RowSource, MagnusError> {
+    if read_from.is_kind_of(ruby.class_array()) {
+        return Ok(RowSource::Materialized(TryConvert::try_convert(read_from)?));
+    }
+
+    if read_from.respond_to("each_slice", false)? {
+        // One fiber switch per slice keeps Enumerator overhead negligible
+        // while bounding how many Ruby rows are in flight at once.
+        let slice_size = batch_size.unwrap_or(DEFAULT_ROW_SLICE_SIZE);
+        let mut remaining = read_from.enumeratorize("each_slice", (slice_size,));
+        let first_slice = match remaining.next() {
+            Some(slice) => Some(TryConvert::try_convert(slice?)?),
+            None => None,
+        };
+        return Ok(RowSource::Streamed {
+            first_slice,
+            remaining,
+        });
+    }
+
+    if read_from.respond_to("to_a", false)? {
+        let array_value: Value = read_from.funcall("to_a", ())?;
+        return Ok(RowSource::Materialized(TryConvert::try_convert(
+            array_value,
+        )?));
+    }
+
+    Err(MagnusError::new(
+        ruby.exception_type_error(),
+        "data must be an array or respond to 'to_a'",
+    ))
+}
+
+/// Map a value-conversion failure to the Ruby exception the write API raises:
+/// encoding problems surface as EncodingError, everything else RuntimeError.
+fn conversion_error(ruby: &Ruby, error_msg: String) -> MagnusError {
+    if error_msg.contains("EncodingError") || error_msg.contains("invalid utf-8") {
+        // Extract the actual encoding error message
+        if let Some(pos) = error_msg.find("EncodingError: ") {
+            let encoding_msg = error_msg[pos + 15..].to_string();
+            MagnusError::new(ruby.exception_encoding_error(), encoding_msg)
+        } else {
+            MagnusError::new(ruby.exception_encoding_error(), error_msg)
+        }
+    } else {
+        MagnusError::new(ruby.exception_runtime_error(), error_msg)
+    }
+}
+
+/// Convert one slice of Ruby rows and write them through the core writer.
+/// Returns the number of rows written.
+///
+/// `release_consumed` should be true only when `rows` is an array this module
+/// created itself (an `each_slice` slice): each element is dropped from the
+/// slice once converted, so large rows become collectable while the rest of
+/// the slice is still being written. User-provided arrays must not be mutated.
+fn write_row_slice(
+    ruby: &Ruby,
+    writer_output: &mut WriterOutput,
+    converter: &mut crate::converter::RubyValueConverter,
+    field_schemas: &[parquet_core::SchemaNode],
+    rows: RArray,
+    release_consumed: bool,
+) -> Result<u64, MagnusError> {
+    let mut rows_written = 0u64;
+
+    for (row_idx, row_value) in rows.into_iter().enumerate() {
+        // Convert Ruby row to ParquetValue vector
+        let row = if row_value.is_kind_of(ruby.class_array()) {
+            let array: RArray = TryConvert::try_convert(row_value)?;
+            let mut values = Vec::with_capacity(array.len());
+
+            for (idx, item) in array.into_iter().enumerate() {
+                let schema_hint = field_schemas.get(idx);
+                let pq_value = converter
+                    .to_parquet_with_schema_hint(item, schema_hint)
+                    .map_err(|e| conversion_error(ruby, e.to_string()))?;
+                values.push(pq_value);
+            }
+            values
+        } else {
+            return Err(MagnusError::new(
+                ruby.exception_type_error(),
+                "each row must be an array",
+            ));
+        };
+
+        if release_consumed {
+            rows.store(row_idx as isize, ruby.qnil())?;
+        }
+
+        match writer_output {
+            WriterOutput::File(writer) | WriterOutput::TempFile(writer, _, _) => {
+                writer
+                    .write_row(row)
+                    .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            }
+        }
+        rows_written += 1;
+    }
+
+    Ok(rows_written)
+}
+
 /// Write data in row format to a parquet file
 pub fn write_rows(
     ruby: &Ruby,
@@ -134,25 +261,30 @@ pub fn write_rows(
     use crate::logger::RubyLogger;
     use crate::schema::{extract_field_schemas, process_schema_value, ruby_schema_to_parquet};
     use crate::string_cache::StringCache;
-    use magnus::{RArray, TryConvert};
 
-    // Convert data to array if it isn't already
-    let data_array = if write_args.read_from.is_kind_of(ruby.class_array()) {
-        TryConvert::try_convert(write_args.read_from)?
-    } else if write_args.read_from.respond_to("to_a", false)? {
-        let array_value: Value = write_args.read_from.funcall("to_a", ())?;
-        TryConvert::try_convert(array_value)?
-    } else {
-        return Err(MagnusError::new(
-            ruby.exception_type_error(),
-            "data must be an array or respond to 'to_a'",
-        ));
+    // Read rows lazily where possible: draining an Enumerator up front would
+    // hold the entire dataset in memory for the duration of the write.
+    let source = row_source(ruby, write_args.read_from, write_args.batch_size)?;
+
+    // Schema inference (used when `schema` is nil/empty) only inspects the
+    // first row, so the first slice is enough.
+    let empty_rows;
+    let inference_rows = match &source {
+        RowSource::Materialized(rows) => rows,
+        RowSource::Streamed {
+            first_slice: Some(rows),
+            ..
+        } => rows,
+        RowSource::Streamed {
+            first_slice: None, ..
+        } => {
+            empty_rows = ruby.ary_new();
+            &empty_rows
+        }
     };
 
-    let data_array: RArray = data_array;
-
     // Process schema value
-    let schema_hash = process_schema_value(ruby, write_args.schema_value, Some(&data_array))
+    let schema_hash = process_schema_value(ruby, write_args.schema_value, Some(inference_rows))
         .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
 
     // Create schema
@@ -190,54 +322,47 @@ pub fn write_rows(
     };
 
     // Stream each row to the core writer, which buffers and flushes internally
-    // according to its (now sole) batch-sizing policy.
+    // according to its (now sole) batch-sizing policy. Completed row groups
+    // reach the destination while later rows are still being produced.
     let mut total_rows = 0u64;
 
-    for row_value in data_array.into_iter() {
-        // Convert Ruby row to ParquetValue vector
-        let row = if row_value.is_kind_of(ruby.class_array()) {
-            let array: RArray = TryConvert::try_convert(row_value)?;
-            let mut values = Vec::with_capacity(array.len());
-
-            for (idx, item) in array.into_iter().enumerate() {
-                let schema_hint = field_schemas.get(idx);
-                let pq_value = converter
-                    .to_parquet_with_schema_hint(item, schema_hint)
-                    .map_err(|e| {
-                        let error_msg = e.to_string();
-                        // Check if this is an encoding error
-                        if error_msg.contains("EncodingError")
-                            || error_msg.contains("invalid utf-8")
-                        {
-                            // Extract the actual encoding error message
-                            if let Some(pos) = error_msg.find("EncodingError: ") {
-                                let encoding_msg = error_msg[pos + 15..].to_string();
-                                MagnusError::new(ruby.exception_encoding_error(), encoding_msg)
-                            } else {
-                                MagnusError::new(ruby.exception_encoding_error(), error_msg)
-                            }
-                        } else {
-                            MagnusError::new(ruby.exception_runtime_error(), error_msg)
-                        }
-                    })?;
-                values.push(pq_value);
+    match source {
+        RowSource::Materialized(rows) => {
+            total_rows += write_row_slice(
+                ruby,
+                &mut writer_output,
+                &mut converter,
+                &field_schemas,
+                rows,
+                false,
+            )?;
+        }
+        RowSource::Streamed {
+            first_slice,
+            remaining,
+        } => {
+            if let Some(rows) = first_slice {
+                total_rows += write_row_slice(
+                    ruby,
+                    &mut writer_output,
+                    &mut converter,
+                    &field_schemas,
+                    rows,
+                    true,
+                )?;
             }
-            values
-        } else {
-            return Err(MagnusError::new(
-                ruby.exception_type_error(),
-                "each row must be an array",
-            ));
-        };
-
-        match &mut writer_output {
-            WriterOutput::File(writer) | WriterOutput::TempFile(writer, _, _) => {
-                writer
-                    .write_row(row)
-                    .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            for slice in remaining {
+                let rows: RArray = TryConvert::try_convert(slice?)?;
+                total_rows += write_row_slice(
+                    ruby,
+                    &mut writer_output,
+                    &mut converter,
+                    &field_schemas,
+                    rows,
+                    true,
+                )?;
             }
         }
-        total_rows += 1;
     }
 
     // The core writer flushes any remaining buffered rows when closed by
@@ -264,35 +389,157 @@ pub fn write_rows(
     Ok(ruby.qnil().as_value())
 }
 
+/// The column batches to write, either already materialized or pulled lazily
+/// from an Enumerable one batch at a time.
+enum BatchSource {
+    Materialized(RArray),
+    Streamed {
+        first_batch: Option<Value>,
+        remaining: Enumerator,
+    },
+}
+
+/// Classify `read_from` without draining it, mirroring `row_source`. Batches
+/// are chunky (whole columns), so streamed sources are pulled one batch per
+/// fiber switch via `each`.
+fn batch_source(ruby: &Ruby, read_from: Value) -> Result<BatchSource, MagnusError> {
+    if read_from.is_kind_of(ruby.class_array()) {
+        return Ok(BatchSource::Materialized(TryConvert::try_convert(
+            read_from,
+        )?));
+    }
+
+    if read_from.respond_to("each", false)? {
+        let mut remaining = read_from.enumeratorize("each", ());
+        let first_batch = remaining.next().transpose()?;
+        return Ok(BatchSource::Streamed {
+            first_batch,
+            remaining,
+        });
+    }
+
+    if read_from.respond_to("to_a", false)? {
+        let array_value: Value = read_from.funcall("to_a", ())?;
+        return Ok(BatchSource::Materialized(TryConvert::try_convert(
+            array_value,
+        )?));
+    }
+
+    Err(MagnusError::new(
+        ruby.exception_type_error(),
+        "data must be an array or respond to 'to_a'",
+    ))
+}
+
+/// Convert one Ruby batch (an array of per-column value arrays) and write it
+/// through the core writer as a record batch. Returns the batch's row count.
+fn write_column_batch(
+    ruby: &Ruby,
+    writer_output: &mut WriterOutput,
+    field_schemas: &[parquet_core::SchemaNode],
+    column_names: &[String],
+    batch: Value,
+) -> Result<usize, MagnusError> {
+    use crate::converter::RubyValueConverter;
+
+    if !batch.is_kind_of(ruby.class_array()) {
+        return Err(MagnusError::new(
+            ruby.exception_type_error(),
+            "each batch must be an array of column values",
+        ));
+    }
+
+    let batch_array: RArray = TryConvert::try_convert(batch)?;
+
+    // Verify batch has the right number of columns
+    if batch_array.len() != column_names.len() {
+        return Err(MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!(
+                "Batch has {} columns but schema has {}",
+                batch_array.len(),
+                column_names.len()
+            ),
+        ));
+    }
+
+    let mut batch_columns: Vec<(String, Vec<parquet_core::ParquetValue>)> =
+        Vec::with_capacity(column_names.len());
+
+    // Process each column in the batch
+    for (col_idx, column_values) in batch_array.into_iter().enumerate() {
+        if !column_values.is_kind_of(ruby.class_array()) {
+            return Err(MagnusError::new(
+                ruby.exception_type_error(),
+                format!("Column {} values must be an array", col_idx),
+            ));
+        }
+
+        let values_array: RArray = TryConvert::try_convert(column_values)?;
+
+        // Convert and append values
+        let mut converter = RubyValueConverter::new();
+        let schema_hint = field_schemas.get(col_idx);
+
+        let mut values = Vec::with_capacity(values_array.len());
+        for value in values_array.into_iter() {
+            let pq_value = converter
+                .to_parquet_with_schema_hint(value, schema_hint)
+                .map_err(|e| conversion_error(ruby, e.to_string()))?;
+            values.push(pq_value);
+        }
+        batch_columns.push((column_names[col_idx].clone(), values));
+    }
+
+    let batch_rows = batch_columns
+        .first()
+        .map(|(_name, values)| values.len())
+        .unwrap_or(0);
+
+    // Write this batch immediately; the core writer flushes completed row
+    // groups to the destination once its in-progress buffer exceeds the
+    // flush threshold.
+    match writer_output {
+        WriterOutput::File(writer) | WriterOutput::TempFile(writer, _, _) => {
+            writer
+                .write_columns(batch_columns)
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+        }
+    }
+
+    Ok(batch_rows)
+}
+
 /// Write data in column format to a parquet file
 pub fn write_columns(
     ruby: &Ruby,
     write_args: crate::types::ParquetWriteArgs,
 ) -> Result<Value, MagnusError> {
-    use crate::converter::RubyValueConverter;
     use crate::logger::RubyLogger;
     use crate::schema::{extract_field_schemas, process_schema_value, ruby_schema_to_parquet};
-    use magnus::{RArray, TryConvert};
 
     let logger = RubyLogger::new(write_args.logger)?;
 
-    // Convert data to array for processing
-    let data_array = if write_args.read_from.is_kind_of(ruby.class_array()) {
-        TryConvert::try_convert(write_args.read_from)?
-    } else if write_args.read_from.respond_to("to_a", false)? {
-        let array_value: Value = write_args.read_from.funcall("to_a", ())?;
-        TryConvert::try_convert(array_value)?
-    } else {
-        return Err(MagnusError::new(
-            ruby.exception_type_error(),
-            "data must be an array or respond to 'to_a'",
-        ));
+    // Read batches lazily where possible: draining an Enumerator up front
+    // would hold every batch in memory for the duration of the write.
+    let source = batch_source(ruby, write_args.read_from)?;
+
+    // Schema inference (used when `schema` is nil/empty) only inspects the
+    // first batch, so one batch is enough.
+    let first_batch_holder;
+    let inference_batches = match &source {
+        BatchSource::Materialized(batches) => batches,
+        BatchSource::Streamed { first_batch, .. } => {
+            first_batch_holder = ruby.ary_new();
+            if let Some(batch) = first_batch {
+                first_batch_holder.push(*batch)?;
+            }
+            &first_batch_holder
+        }
     };
 
-    let data_array: RArray = data_array;
-
     // Process schema value
-    let schema_hash = process_schema_value(ruby, write_args.schema_value, Some(&data_array))
+    let schema_hash = process_schema_value(ruby, write_args.schema_value, Some(inference_batches))
         .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
 
     // Create schema
@@ -328,88 +575,44 @@ pub fn write_columns(
             ));
         };
 
-    // Convert data to columns format
-    let mut all_columns: Vec<(String, Vec<parquet_core::ParquetValue>)> = Vec::new();
+    // Convert and write each batch as it arrives; completed row groups are
+    // flushed to the destination instead of accumulating every batch first.
+    let mut total_rows: usize = 0;
 
-    // Process batches
-    for (batch_idx, batch) in data_array.into_iter().enumerate() {
-        if !batch.is_kind_of(ruby.class_array()) {
-            return Err(MagnusError::new(
-                ruby.exception_type_error(),
-                "each batch must be an array of column values",
-            ));
-        }
-
-        let batch_array: RArray = TryConvert::try_convert(batch)?;
-
-        // Verify batch has the right number of columns
-        if batch_array.len() != column_names.len() {
-            return Err(MagnusError::new(
-                ruby.exception_runtime_error(),
-                format!(
-                    "Batch has {} columns but schema has {}",
-                    batch_array.len(),
-                    column_names.len()
-                ),
-            ));
-        }
-
-        // Process each column in the batch
-        for (col_idx, column_values) in batch_array.into_iter().enumerate() {
-            if !column_values.is_kind_of(ruby.class_array()) {
-                return Err(MagnusError::new(
-                    ruby.exception_type_error(),
-                    format!("Column {} values must be an array", col_idx),
-                ));
-            }
-
-            let values_array: RArray = TryConvert::try_convert(column_values)?;
-
-            // Initialize column vector on first batch
-            if batch_idx == 0 {
-                all_columns.push((column_names[col_idx].clone(), Vec::new()));
-            }
-
-            // Convert and append values
-            let mut converter = RubyValueConverter::new();
-            let schema_hint = field_schemas.get(col_idx);
-
-            for value in values_array.into_iter() {
-                let pq_value = converter
-                    .to_parquet_with_schema_hint(value, schema_hint)
-                    .map_err(|e| {
-                        let error_msg = e.to_string();
-                        // Check if this is an encoding error
-                        if error_msg.contains("EncodingError")
-                            || error_msg.contains("invalid utf-8")
-                        {
-                            // Extract the actual encoding error message
-                            if let Some(pos) = error_msg.find("EncodingError: ") {
-                                let encoding_msg = error_msg[pos + 15..].to_string();
-                                MagnusError::new(ruby.exception_encoding_error(), encoding_msg)
-                            } else {
-                                MagnusError::new(ruby.exception_encoding_error(), error_msg)
-                            }
-                        } else {
-                            MagnusError::new(ruby.exception_runtime_error(), error_msg)
-                        }
-                    })?;
-                all_columns[col_idx].1.push(pq_value);
+    match source {
+        BatchSource::Materialized(batches) => {
+            for batch in batches.into_iter() {
+                total_rows += write_column_batch(
+                    ruby,
+                    &mut writer_output,
+                    &field_schemas,
+                    &column_names,
+                    batch,
+                )?;
             }
         }
-    }
-
-    let total_rows = all_columns
-        .first()
-        .map(|(_name, values)| values.len())
-        .unwrap_or(0);
-
-    // Write the columns
-    match &mut writer_output {
-        WriterOutput::File(writer) | WriterOutput::TempFile(writer, _, _) => {
-            writer
-                .write_columns(all_columns)
-                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+        BatchSource::Streamed {
+            first_batch,
+            remaining,
+        } => {
+            if let Some(batch) = first_batch {
+                total_rows += write_column_batch(
+                    ruby,
+                    &mut writer_output,
+                    &field_schemas,
+                    &column_names,
+                    batch,
+                )?;
+            }
+            for batch in remaining {
+                total_rows += write_column_batch(
+                    ruby,
+                    &mut writer_output,
+                    &field_schemas,
+                    &column_names,
+                    batch?,
+                )?;
+            }
         }
     }
 

--- a/lib/parquet.rbi
+++ b/lib/parquet.rbi
@@ -102,9 +102,11 @@ module Parquet
   #     - `timestamp_millis`, `timestamp_micros`
   #   - `write_to`: String path or IO object to write the parquet file to
   #   - `batch_size`: Optional positive batch size for writing (defaults to 1000, at most 1_000_000
-  #                   for one-column schemas; wide schemas may have a lower safety cap)
-  #   - `flush_threshold`: Optional threshold in bytes for the writer's in-progress (encoded)
-  #                        buffer before a row group is flushed (defaults to 100MB)
+  #                   for one-column schemas; wide schemas may have a lower safety cap). Enumerator
+  #                   inputs are consumed in slices of this many rows, never materialized in full.
+  #   - `flush_threshold`: Optional threshold in bytes before a row group is flushed to the
+  #                        destination; bounds both the raw bytes staged since the last flush
+  #                        and the writer's encoded in-progress buffer (defaults to 100MB)
   #   - `compression`: Optional compression type to use (defaults to "zstd")
   #                   Supported values: "none", "uncompressed", "snappy", "gzip", "lz4", "zstd"
   #   - `sample_size`: Optional positive number of rows to sample for size estimation
@@ -151,8 +153,9 @@ module Parquet
   #     - `timestamp_millis`, `timestamp_micros`
   #     - Looks like [{"column_name" => {"type" => "date32", "format" => "%Y-%m-%d"}}, {"column_name" => "int8"}]
   #   - `write_to`: String path or IO object to write the parquet file to
-  #   - `flush_threshold`: Optional threshold in bytes for the writer's in-progress (encoded)
-  #                        buffer before a row group is flushed (defaults to 100MB)
+  #   - `flush_threshold`: Optional threshold in bytes before a row group is flushed to the
+  #                        destination; bounds both the raw bytes staged since the last flush
+  #                        and the writer's encoded in-progress buffer (defaults to 100MB)
   #   - `compression`: Optional compression type to use (defaults to "zstd")
   #                   Supported values: "none", "uncompressed", "snappy", "gzip", "lz4", "zstd"
   #   - `logger`: Optional Ruby logger for column-write progress messages

--- a/test/memory_usage_test.rb
+++ b/test/memory_usage_test.rb
@@ -165,6 +165,48 @@ class MemoryUsageTest < Minitest::Test
            "Memory grew by #{memory_stats[:memory_growth_mb].round(2)}MB, expected < 100MB"
   end
 
+  def test_writing_enumerator_streams_with_bounded_peak_memory
+    # Regression test: write_rows used to drain the entire Enumerator into a
+    # Ruby array before writing, so peak RSS tracked the total dataset size.
+    # With streaming, peak RSS must stay bounded by batch/flush sizes.
+    row_count = 1_000_000
+    payload = 100
+
+    schema = {
+      fields: [
+        {name: 'id', type: :int64},
+        {name: 'payload', type: :string}
+      ]
+    }
+
+    GC.start(full_mark: true, immediate_sweep: true)
+    baseline_mb = current_memory_mb
+    peak_mb = baseline_mb
+
+    rows = Enumerator.new do |y|
+      row_count.times do |i|
+        peak_mb = [peak_mb, current_memory_mb].max if (i % 100_000).zero?
+        y << [i, "#{i}-#{'x' * payload}"]
+      end
+    end
+
+    Parquet.write_rows(rows, schema: schema, write_to: @test_file,
+                       batch_size: 5000, compression: "zstd")
+
+    peak_growth_mb = peak_mb - baseline_mb
+    puts "Enumerator write peak growth: #{peak_growth_mb.round(2)}MB" if ENV["VERBOSE"]
+
+    # ~100MB of raw row data is produced; before the streaming fix, peak
+    # growth was ~2-3x the total data size (all rows resident at once).
+    assert peak_growth_mb < 100,
+           "Peak memory grew by #{peak_growth_mb.round(2)}MB during enumerator write, expected < 100MB"
+
+    # The whole dataset must still round-trip.
+    count = 0
+    Parquet.each_row(@test_file) { |_row| count += 1 }
+    assert_equal row_count, count
+  end
+
   def test_concurrent_reading_memory_efficiency
     # Create a moderately large file
     row_count = 100_000

--- a/test/write_streaming_test.rb
+++ b/test/write_streaming_test.rb
@@ -1,0 +1,243 @@
+require_relative 'test_helper'
+require 'tempfile'
+require 'stringio'
+
+# Regression tests for streaming writes: enumerator inputs must not be
+# materialized up front, and completed row groups must reach the destination
+# while the input is still being enumerated (bounded by flush_threshold).
+class WriteStreamingTest < Minitest::Test
+  def setup
+    @test_file = File.join(Dir.tmpdir, "test_write_streaming_#{Process.pid}.parquet")
+  end
+
+  def teardown
+    File.delete(@test_file) if File.exist?(@test_file)
+  end
+
+  def schema
+    {
+      fields: [
+        { name: 'id', type: :int64 },
+        { name: 'payload', type: :string, nullable: true }
+      ]
+    }
+  end
+
+  def payload_for(i, bytes)
+    "#{i}-#{'x' * bytes}"
+  end
+
+  def test_write_rows_enumerator_flushes_to_destination_during_enumeration
+    n_rows = 2_000
+    payload_bytes = 10_000
+    file_sizes = []
+
+    rows = Enumerator.new do |y|
+      n_rows.times do |i|
+        if (i % 500).zero?
+          file_sizes << (File.exist?(@test_file) ? File.size(@test_file) : -1)
+        end
+        y << [i, payload_for(i, payload_bytes)]
+      end
+    end
+
+    # 2000 rows x ~10KB = ~20MB raw staged bytes against a 512KB threshold:
+    # row groups must be flushed to the file long before enumeration ends.
+    Parquet.write_rows(rows, schema: schema, write_to: @test_file,
+                       batch_size: 100, flush_threshold: 512 * 1024,
+                       compression: "zstd")
+
+    assert file_sizes.last > 0,
+           "expected destination file to grow during enumeration, sizes: #{file_sizes.inspect}"
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal n_rows, rows_read.length
+    assert_equal 0, rows_read.first['id']
+    assert_equal payload_for(1999, payload_bytes), rows_read.last['payload']
+  end
+
+  %w[none snappy gzip zstd].each do |compression|
+    define_method("test_write_rows_enumerator_multi_row_group_round_trip_#{compression}") do
+      n_rows = 3_000
+      rows = Enumerator.new do |y|
+        n_rows.times do |i|
+          y << [i, (i % 7).zero? ? nil : payload_for(i, 1_000)]
+        end
+      end
+
+      Parquet.write_rows(rows, schema: schema, write_to: @test_file,
+                         batch_size: 200, flush_threshold: 256 * 1024,
+                         compression: compression)
+
+      row_groups = Parquet.metadata(@test_file)["row_groups"]
+      assert row_groups.length > 1,
+             "expected multiple row groups, got #{row_groups.length}"
+
+      count = 0
+      Parquet.each_row(@test_file) do |row|
+        assert_equal count, row['id']
+        if (count % 7).zero?
+          assert_nil row['payload']
+        else
+          assert_equal payload_for(count, 1_000), row['payload']
+        end
+        count += 1
+      end
+      assert_equal n_rows, count
+    end
+  end
+
+  def test_write_columns_enumerator_flushes_to_destination_during_enumeration
+    n_batches = 20
+    batch_rows = 200
+    payload_bytes = 10_000
+    file_sizes = []
+
+    batches = Enumerator.new do |y|
+      n_batches.times do |b|
+        file_sizes << (File.exist?(@test_file) ? File.size(@test_file) : -1)
+        ids = Array.new(batch_rows) { |i| b * batch_rows + i }
+        payloads = ids.map { |id| payload_for(id, payload_bytes) }
+        y << [ids, payloads]
+      end
+    end
+
+    Parquet.write_columns(batches, schema: schema, write_to: @test_file,
+                          flush_threshold: 512 * 1024, compression: "zstd")
+
+    assert file_sizes.last > 0,
+           "expected destination file to grow during enumeration, sizes: #{file_sizes.inspect}"
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal n_batches * batch_rows, rows_read.length
+    rows_read.each_with_index do |row, i|
+      assert_equal i, row['id']
+    end
+    assert_equal payload_for(3999, payload_bytes), rows_read.last['payload']
+  end
+
+  def test_write_columns_enumerator_round_trips_with_nils
+    batches = Enumerator.new do |y|
+      3.times do |b|
+        ids = Array.new(50) { |i| b * 50 + i }
+        payloads = ids.map { |id| (id % 5).zero? ? nil : "p#{id}" }
+        y << [ids, payloads]
+      end
+    end
+
+    Parquet.write_columns(batches, schema: schema, write_to: @test_file)
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal 150, rows_read.length
+    rows_read.each_with_index do |row, i|
+      assert_equal i, row['id']
+      if (i % 5).zero?
+        assert_nil row['payload']
+      else
+        assert_equal "p#{i}", row['payload']
+      end
+    end
+  end
+
+  def test_write_columns_empty_enumerator_with_schema
+    batches = Enumerator.new { |_y| }
+
+    Parquet.write_columns(batches, schema: schema, write_to: @test_file)
+
+    assert File.exist?(@test_file)
+    assert_equal [], Parquet.each_row(@test_file).to_a
+  end
+
+  def test_write_columns_enumerator_infers_schema_from_first_batch
+    batches = Enumerator.new do |y|
+      y << [%w[a b], %w[x y]]
+      y << [%w[c d], %w[z w]]
+    end
+
+    Parquet.write_columns(batches, schema: nil, write_to: @test_file)
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal 4, rows_read.length
+    assert_equal "a", rows_read.first['f0']
+    assert_equal "w", rows_read.last['f1']
+  end
+
+  def test_write_rows_rejects_zero_flush_threshold
+    error = assert_raises(ArgumentError) do
+      Parquet.write_rows([[1, "a"]], schema: schema, write_to: @test_file,
+                         flush_threshold: 0)
+    end
+    assert_match(/flush_threshold must be positive/, error.message)
+  end
+
+  def test_write_rows_empty_enumerator_with_schema
+    rows = Enumerator.new { |_y| }
+
+    Parquet.write_rows(rows, schema: schema, write_to: @test_file)
+
+    assert File.exist?(@test_file)
+    assert_equal [], Parquet.each_row(@test_file).to_a
+  end
+
+  def test_write_rows_enumerator_infers_schema_from_first_slice
+    rows = Enumerator.new do |y|
+      100.times { |i| y << ["name#{i}", "value#{i}"] }
+    end
+
+    Parquet.write_rows(rows, schema: nil, write_to: @test_file)
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal 100, rows_read.length
+    assert_equal "name0", rows_read.first['f0']
+    assert_equal "value99", rows_read.last['f1']
+  end
+
+  def test_write_rows_lazy_enumerator
+    rows = (0...500).lazy.map { |i| [i, "payload#{i}"] }
+
+    Parquet.write_rows(rows, schema: schema, write_to: @test_file, batch_size: 50)
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal 500, rows_read.length
+    assert_equal "payload499", rows_read.last['payload']
+  end
+
+  def test_write_rows_object_with_only_to_a_still_works
+    to_a_only = Object.new
+    def to_a_only.to_a = (0...10).map { |i| [i, "p#{i}"] }
+
+    Parquet.write_rows(to_a_only, schema: schema, write_to: @test_file)
+
+    rows_read = Parquet.each_row(@test_file).to_a
+    assert_equal 10, rows_read.length
+    assert_equal "p9", rows_read.last['payload']
+  end
+
+  def test_write_rows_enumerator_to_io_destination
+    rows = Enumerator.new do |y|
+      1_000.times { |i| y << [i, payload_for(i, 1_000)] }
+    end
+
+    io = StringIO.new
+    io.binmode
+    Parquet.write_rows(rows, schema: schema, write_to: io,
+                       batch_size: 100, flush_threshold: 64 * 1024)
+    io.rewind
+
+    rows_read = Parquet.each_row(io).to_a
+    assert_equal 1_000, rows_read.length
+    assert_equal payload_for(999, 1_000), rows_read.last['payload']
+  end
+
+  def test_write_rows_enumerator_error_propagates
+    rows = Enumerator.new do |y|
+      y << [0, "ok"]
+      raise ArgumentError, "boom mid-stream"
+    end
+
+    error = assert_raises(ArgumentError) do
+      Parquet.write_rows(rows, schema: schema, write_to: @test_file, batch_size: 1)
+    end
+    assert_match(/boom mid-stream/, error.message)
+  end
+end


### PR DESCRIPTION
# Overview

Our Rails application needed to write millions of rows to a parquet in a background job. The memory bloat problem causes our job runner to run out of memory because no rows are written to disk until all rows are loaded into memory. We don't have millions of rows of memory. This allows for flat memory usage instead of linear growth.

This fix has been verified in our production environment. No more memory bloat. Its published as gem "parquet-tyfoom" for the short time between this PR and parquet-ruby releasing the updated version.

## Root cause — three layers buffered independently

- The adapter drained the entire enumerator before writing (writer.rs): write_rows called read_from.to_a on any non-Array input, materializing every row as a Ruby array before the output file was even created. This alone explains the linear RSS growth and the 0-byte file during enumeration. write_columns additionally accumulated all converted batches into one all_columns vec and wrote them in a single call at the end.
- flush_threshold was compared only against the encoded buffer (parquet-core writer.rs): the flush check used arrow's in_progress_size()/memory_size(), which measure compressed, encoded pages. Compressible data (like the reproducer's payloads, which zstd shrinks 5000:1) never approached the threshold, so every row group stayed in memory until close(). The write_columns path had no flush check at all.
- A transient amplifier: string/binary array builders were created with zero data capacity, so building a large string column doubled its way up — up to ~3× the payload held transiently per flush (visible in RSS because the Rust side uses jemalloc, which retains freed pages).

## The fix

- write_rows now streams Enumerable inputs via each_slice(batch_size) (one fiber switch per slice; default 1000 rows), infers the schema from the first slice only, and releases each slice element once converted. write_columns writes each batch as it arrives and streams enumerator inputs one batch at a time. Plain Arrays and to_a-only objects behave exactly as before; error classes/messages are unchanged.
- The core writer tracks raw staged bytes since the last row-group flush and flushes when they exceed flush_threshold — checked mid-batch, at batch boundaries, and on the write_columns path — alongside the existing encoded-size checks. Builders now pre-size their data buffers exactly.
- flush_threshold: 0 is rejected like batch_size: 0 (it would otherwise mean one row group per row).
- Before/after (aarch64-linux, Ruby 3.4, zstd, unique payloads, VmHWM)

| Case |	Before |	After |	File during write |
| --- | ---|---|---|
| 5,000 × 100KB, batch 250, flush 16MB |	~925MB (issue) / 720MB measured |	186MB |	grows (was 0 until close) |
| 2,000,000 × 100B, batch 5000 |	~975MB (issue) / 573MB measured |	42MB |	grows (was 0 until close) |

- For scale: just enumerating the reproducer's rows in pure Ruby (no parquet) peaks at 112MB, so the writer's true overhead is now ~75MB.

## Verification

- Full Ruby suite: 201 runs, 0 failures on both macOS and Linux (Docker, aarch64); Rust suite 181 passed. Round-trip fidelity covered for zstd/snappy/gzip/none with nils and multi-row-group files.
- New test/write_streaming_test.rb (14 tests) uses the deterministic proxy you suggested — asserting the destination file is non-empty partway through enumeration — plus IO-destination, lazy-enumerator, empty-enumerator, inference, and error-propagation coverage. An RSS-based peak-memory test went into memory_usage_test.rb behind the existing RUN_SLOW_TESTS gate.
- README, CHANGELOG, and parquet.rbi updated to the new semantics, including the documented caveat that IO-object destinations are staged through a temp file on disk (memory-bounded) and receive bytes only at finalize.
- A multi-agent adversarial review ran over the diff; it surfaced the flush_threshold: 0 row-group-explosion hazard and two test-quality issues, all fixed.

## Other Notes

row-group boundaries now land every ~flush_threshold of raw data rather than one giant group, and a mid-stream enumerator exception leaves a partial file (the file is created once the first slice arrives — the same thing that already happened on mid-write conversion errors).