### PR TITLE
add repacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add `Parquet.repack` for streaming Parquet files with matching schemas
 - `string_cache:` on `Parquet.write_rows` now also accepts an Integer to set the cache
   capacity (`true` uses the default, `false` disables); a non-positive, excessive,
   or non-boolean/non-integer value is rejected. Retention is bounded by entry count,

--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ Parquet.write_rows(rows,
 )
 ```
 
+### Repacking Existing Parquet Files
+
+Concatenate and/or split Parquet files with matching schemas while preserving the input schema.
+
+```ruby
+Parquet.repack(
+  ["input-0.parquet", "input-1.parquet"],
+  output_file_prefix: "batch",
+  output_dir: "repacked",
+  rows_per_file: 100_000,
+  max_read_rows_per_chunk: 8192,
+  compression: "zstd"
+)
+```
+
+Omit `rows_per_file:` to concatenate all input rows into a single output file.
+
 ### Column-wise Writing
 
 Best for: Pre-columnar data, better compression, higher performance

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Parquet.repack(
 ```
 
 Omit `rows_per_file:` to concatenate all input rows into a single output file.
+`max_read_rows_per_chunk:` is an upper bound; wide schemas may use a smaller
+effective read chunk to keep buffered value slots bounded.
 
 ### Column-wise Writing
 

--- a/ext/parquet-core/src/lib.rs
+++ b/ext/parquet-core/src/lib.rs
@@ -57,4 +57,6 @@ pub use error::{ErrorContext, ParquetError, Result};
 pub use reader::Reader;
 pub use schema::{PrimitiveType, Repetition, Schema, SchemaBuilder, SchemaNode};
 pub use value::ParquetValue;
-pub use writer::{Writer, WriterBuilder, MAX_BATCH_SIZE, MAX_SAMPLE_SIZE};
+pub use writer::{
+    max_batch_size_for_column_count, Writer, WriterBuilder, MAX_BATCH_SIZE, MAX_SAMPLE_SIZE,
+};

--- a/ext/parquet-core/src/writer.rs
+++ b/ext/parquet-core/src/writer.rs
@@ -688,7 +688,7 @@ fn validate_column_count(column_count: usize) -> Result<()> {
     Ok(())
 }
 
-fn max_batch_size_for_column_count(column_count: usize) -> usize {
+pub fn max_batch_size_for_column_count(column_count: usize) -> usize {
     let width = column_count.max(1);
     (MAX_BUFFERED_VALUE_SLOTS / width)
         .max(1)

--- a/ext/parquet-ruby-adapter/src/lib.rs
+++ b/ext/parquet-ruby-adapter/src/lib.rs
@@ -72,13 +72,14 @@ pub use metadata::{parse_metadata, RubyParquetMetaData};
 
 pub mod types;
 pub use types::{
-    ColumnEnumeratorArgs, ParquetWriteArgs, ParserResultType, RowEnumeratorArgs, WriterOutput,
+    ColumnEnumeratorArgs, ParquetRepackArgs, ParquetWriteArgs, ParserResultType,
+    RowEnumeratorArgs, WriterOutput,
 };
 
 pub mod utils;
 pub use utils::{
     create_column_enumerator, create_row_enumerator, handle_block_or_enum, parse_compression,
-    parse_parquet_write_args,
+    parse_parquet_repack_args, parse_parquet_write_args,
 };
 
 pub mod reader;
@@ -86,6 +87,9 @@ pub use reader::{each_column, each_row};
 
 pub mod writer;
 pub use writer::{create_writer, finalize_writer, write_columns, write_rows};
+
+pub mod repack;
+pub use repack::repack;
 
 pub mod try_into_value;
 pub use try_into_value::TryIntoValue;

--- a/ext/parquet-ruby-adapter/src/repack.rs
+++ b/ext/parquet-ruby-adapter/src/repack.rs
@@ -1,11 +1,15 @@
 use std::fs::{self, File};
+use std::os::raw::c_void;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
+use std::ptr;
 
 use arrow_schema::SchemaRef;
 use magnus::value::ReprValue;
 use magnus::{Error as MagnusError, Ruby, Value};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use tempfile::{NamedTempFile, TempPath};
 
@@ -32,9 +36,16 @@ struct CompletedOutput {
     num_rows: usize,
 }
 
+struct RepackWithoutGvlState {
+    args: Option<ParquetRepackArgs>,
+    compression: Compression,
+    result: Option<std::thread::Result<Result<Vec<RepackedFile>, String>>>,
+}
+
 pub fn repack(ruby: &Ruby, args: &[Value]) -> Result<Value, MagnusError> {
     let repack_args = parse_parquet_repack_args(ruby, args)?;
-    let files = repack_files(ruby, &repack_args)?;
+    let compression = parse_compression(ruby, repack_args.compression.clone())?;
+    let files = repack_without_gvl(ruby, repack_args, compression)?;
 
     let result = ruby.ary_new_capa(files.len());
     for file in files {
@@ -47,12 +58,70 @@ pub fn repack(ruby: &Ruby, args: &[Value]) -> Result<Value, MagnusError> {
     Ok(result.as_value())
 }
 
-fn repack_files(
+fn repack_without_gvl(
     ruby: &Ruby,
-    args: &ParquetRepackArgs,
+    args: ParquetRepackArgs,
+    compression: Compression,
 ) -> Result<Vec<RepackedFile>, MagnusError> {
-    let schema = read_schema(ruby, &args.read_from[0])?;
-    validate_input_schemas(ruby, args, schema.clone())?;
+    let mut state = RepackWithoutGvlState {
+        args: Some(args),
+        compression,
+        result: None,
+    };
+
+    magnus::rb_sys::protect(|| {
+        unsafe {
+            rb_sys::rb_thread_call_without_gvl(
+                Some(repack_without_gvl_trampoline),
+                (&mut state as *mut RepackWithoutGvlState).cast::<c_void>(),
+                None,
+                ptr::null_mut(),
+            );
+        }
+        rb_sys::Qnil as rb_sys::VALUE
+    })?;
+
+    match state
+        .result
+        .take()
+        .expect("rb_thread_call_without_gvl must set a result")
+    {
+        Ok(Ok(files)) => Ok(files),
+        Ok(Err(message)) => Err(MagnusError::new(ruby.exception_runtime_error(), message)),
+        Err(payload) => Err(MagnusError::new(
+            ruby.exception_runtime_error(),
+            panic_message(payload),
+        )),
+    }
+}
+
+unsafe extern "C" fn repack_without_gvl_trampoline(data: *mut c_void) -> *mut c_void {
+    let state = unsafe { &mut *data.cast::<RepackWithoutGvlState>() };
+    state.result = Some(catch_unwind(AssertUnwindSafe(|| {
+        let args = state.args.take().expect("repack arguments must be present");
+        let compression = state.compression;
+        repack_files(&args, compression)
+    })));
+
+    ptr::null_mut()
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        format!("Parquet.repack panicked: {message}")
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        format!("Parquet.repack panicked: {message}")
+    } else {
+        "Parquet.repack panicked".to_string()
+    }
+}
+
+fn repack_files(
+    args: &ParquetRepackArgs,
+    compression: Compression,
+) -> Result<Vec<RepackedFile>, String> {
+    let schema = read_schema(&args.read_from[0])?;
+    validate_input_schemas(args, schema.clone())?;
 
     let mut completed_outputs = Vec::new();
     let mut output_index = 0usize;
@@ -60,19 +129,23 @@ fn repack_files(
     let mut current_output = None;
 
     for input_path in &args.read_from {
-        let reader = create_reader_builder(ruby, input_path)?
+        let reader = create_reader_builder(input_path)?
             .with_batch_size(args.max_read_rows_per_chunk)
             .build()
-            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            .map_err(|e| e.to_string())?;
 
         for batch_result in reader {
-            let batch = batch_result
-                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            let batch = batch_result.map_err(|e| e.to_string())?;
             let mut offset = 0usize;
 
             while offset < batch.num_rows() {
                 if current_output.is_none() {
-                    current_output = Some(create_output(ruby, args, schema.clone(), output_index)?);
+                    current_output = Some(create_output(
+                        args,
+                        schema.clone(),
+                        output_index,
+                        compression,
+                    )?);
                 }
 
                 let rows_remaining_in_batch = batch.num_rows() - offset;
@@ -89,7 +162,7 @@ fn repack_files(
                 output
                     .writer
                     .write(&batch_slice)
-                    .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
                 output.num_rows += rows_to_write;
 
                 offset += rows_to_write;
@@ -97,7 +170,6 @@ fn repack_files(
 
                 if args.rows_per_file == Some(current_output_rows) {
                     completed_outputs.push(close_output(
-                        ruby,
                         current_output.take().expect("output must be present"),
                     )?);
                     output_index += 1;
@@ -108,16 +180,13 @@ fn repack_files(
     }
 
     if let Some(output) = current_output {
-        completed_outputs.push(close_output(ruby, output)?);
+        completed_outputs.push(close_output(output)?);
     }
 
-    persist_outputs(ruby, completed_outputs)
+    persist_outputs(completed_outputs)
 }
 
-fn persist_outputs(
-    ruby: &Ruby,
-    outputs: Vec<CompletedOutput>,
-) -> Result<Vec<RepackedFile>, MagnusError> {
+fn persist_outputs(outputs: Vec<CompletedOutput>) -> Result<Vec<RepackedFile>, String> {
     let mut repacked_files = Vec::with_capacity(outputs.len());
     let mut persisted_paths = Vec::with_capacity(outputs.len());
 
@@ -141,12 +210,9 @@ fn persist_outputs(
                 for persisted_path in persisted_paths {
                     let _ = fs::remove_file(persisted_path);
                 }
-                return Err(MagnusError::new(
-                    ruby.exception_runtime_error(),
-                    format!(
-                        "Failed to move temporary file to '{}': {}",
-                        final_path_string, error.error
-                    ),
+                return Err(format!(
+                    "Failed to move temporary file to '{}': {}",
+                    final_path_string, error.error
                 ));
             }
         }
@@ -155,7 +221,7 @@ fn persist_outputs(
     Ok(repacked_files)
 }
 
-fn close_output(ruby: &Ruby, output: PendingOutput) -> Result<CompletedOutput, MagnusError> {
+fn close_output(output: PendingOutput) -> Result<CompletedOutput, String> {
     let PendingOutput {
         writer,
         temp_file,
@@ -164,9 +230,7 @@ fn close_output(ruby: &Ruby, output: PendingOutput) -> Result<CompletedOutput, M
         num_rows,
     } = output;
 
-    writer
-        .close()
-        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+    writer.close().map_err(|e| e.to_string())?;
 
     Ok(CompletedOutput {
         temp_path: temp_file.into_temp_path(),
@@ -177,18 +241,15 @@ fn close_output(ruby: &Ruby, output: PendingOutput) -> Result<CompletedOutput, M
 }
 
 fn create_output(
-    ruby: &Ruby,
     args: &ParquetRepackArgs,
     schema: SchemaRef,
     output_index: usize,
-) -> Result<PendingOutput, MagnusError> {
+    compression: Compression,
+) -> Result<PendingOutput, String> {
     fs::create_dir_all(&args.output_dir).map_err(|e| {
-        MagnusError::new(
-            ruby.exception_runtime_error(),
-            format!(
-                "Failed to create output directory '{}': {}",
-                args.output_dir, e
-            ),
+        format!(
+            "Failed to create output directory '{}': {}",
+            args.output_dir, e
         )
     })?;
 
@@ -199,31 +260,24 @@ fn create_output(
     let final_path_string = final_path.to_string_lossy().into_owned();
 
     let temp_file = NamedTempFile::new_in(&args.output_dir).map_err(|e| {
-        MagnusError::new(
-            ruby.exception_runtime_error(),
-            format!(
-                "Failed to create temporary output file for '{}': {}",
-                final_path_string, e
-            ),
+        format!(
+            "Failed to create temporary output file for '{}': {}",
+            final_path_string, e
         )
     })?;
 
     let file = temp_file.reopen().map_err(|e| {
-        MagnusError::new(
-            ruby.exception_runtime_error(),
-            format!(
-                "Failed to reopen temporary output file for '{}': {}",
-                final_path_string, e
-            ),
+        format!(
+            "Failed to reopen temporary output file for '{}': {}",
+            final_path_string, e
         )
     })?;
 
     let props = WriterProperties::builder()
-        .set_compression(parse_compression(ruby, args.compression.clone())?)
+        .set_compression(compression)
         .build();
 
-    let writer = ArrowWriter::try_new(file, schema, Some(props))
-        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+    let writer = ArrowWriter::try_new(file, schema, Some(props)).map_err(|e| e.to_string())?;
 
     Ok(PendingOutput {
         writer,
@@ -234,18 +288,14 @@ fn create_output(
     })
 }
 
-fn validate_input_schemas(
-    ruby: &Ruby,
-    args: &ParquetRepackArgs,
-    schema: SchemaRef,
-) -> Result<(), MagnusError> {
+fn validate_input_schemas(args: &ParquetRepackArgs, schema: SchemaRef) -> Result<(), String> {
     for input_path in args.read_from.iter().skip(1) {
-        let input_schema = read_schema(ruby, input_path)?;
+        let input_schema = read_schema(input_path)?;
 
         if input_schema.as_ref() != schema.as_ref() {
-            return Err(MagnusError::new(
-                ruby.exception_runtime_error(),
-                format!("Input file schema does not match first file: {}", input_path),
+            return Err(format!(
+                "Input file schema does not match first file: {}",
+                input_path
             ));
         }
     }
@@ -253,22 +303,14 @@ fn validate_input_schemas(
     Ok(())
 }
 
-fn read_schema(ruby: &Ruby, path: &str) -> Result<SchemaRef, MagnusError> {
-    let builder = create_reader_builder(ruby, path)?;
+fn read_schema(path: &str) -> Result<SchemaRef, String> {
+    let builder = create_reader_builder(path)?;
     Ok(builder.schema().clone())
 }
 
-fn create_reader_builder(
-    ruby: &Ruby,
-    path: &str,
-) -> Result<ParquetRecordBatchReaderBuilder<File>, MagnusError> {
-    let file = File::open(path).map_err(|e| {
-        MagnusError::new(
-            ruby.exception_runtime_error(),
-            format!("Failed to open input file '{}': {}", path, e),
-        )
-    })?;
+fn create_reader_builder(path: &str) -> Result<ParquetRecordBatchReaderBuilder<File>, String> {
+    let file =
+        File::open(path).map_err(|e| format!("Failed to open input file '{}': {}", path, e))?;
 
-    ParquetRecordBatchReaderBuilder::try_new(file)
-        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))
+    ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| e.to_string())
 }

--- a/ext/parquet-ruby-adapter/src/repack.rs
+++ b/ext/parquet-ruby-adapter/src/repack.rs
@@ -1,0 +1,274 @@
+use std::fs::{self, File};
+use std::path::PathBuf;
+
+use arrow_schema::SchemaRef;
+use magnus::value::ReprValue;
+use magnus::{Error as MagnusError, Ruby, Value};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use tempfile::{NamedTempFile, TempPath};
+
+use crate::types::ParquetRepackArgs;
+use crate::utils::{parse_compression, parse_parquet_repack_args};
+
+struct RepackedFile {
+    path: String,
+    num_rows: usize,
+}
+
+struct PendingOutput {
+    writer: ArrowWriter<File>,
+    temp_file: NamedTempFile,
+    final_path: PathBuf,
+    final_path_string: String,
+    num_rows: usize,
+}
+
+struct CompletedOutput {
+    temp_path: TempPath,
+    final_path: PathBuf,
+    final_path_string: String,
+    num_rows: usize,
+}
+
+pub fn repack(ruby: &Ruby, args: &[Value]) -> Result<Value, MagnusError> {
+    let repack_args = parse_parquet_repack_args(ruby, args)?;
+    let files = repack_files(ruby, &repack_args)?;
+
+    let result = ruby.ary_new_capa(files.len());
+    for file in files {
+        let hash = ruby.hash_new();
+        hash.aset("path", file.path)?;
+        hash.aset("num_rows", file.num_rows)?;
+        result.push(hash)?;
+    }
+
+    Ok(result.as_value())
+}
+
+fn repack_files(
+    ruby: &Ruby,
+    args: &ParquetRepackArgs,
+) -> Result<Vec<RepackedFile>, MagnusError> {
+    let schema = read_schema(ruby, &args.read_from[0])?;
+    validate_input_schemas(ruby, args, schema.clone())?;
+
+    let mut completed_outputs = Vec::new();
+    let mut output_index = 0usize;
+    let mut current_output_rows = 0usize;
+    let mut current_output = None;
+
+    for input_path in &args.read_from {
+        let reader = create_reader_builder(ruby, input_path)?
+            .with_batch_size(args.max_read_rows_per_chunk)
+            .build()
+            .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+
+        for batch_result in reader {
+            let batch = batch_result
+                .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+            let mut offset = 0usize;
+
+            while offset < batch.num_rows() {
+                if current_output.is_none() {
+                    current_output = Some(create_output(ruby, args, schema.clone(), output_index)?);
+                }
+
+                let rows_remaining_in_batch = batch.num_rows() - offset;
+                let rows_to_write = match args.rows_per_file {
+                    Some(rows_per_file) => {
+                        let rows_remaining_in_output = rows_per_file - current_output_rows;
+                        rows_remaining_in_batch.min(rows_remaining_in_output)
+                    }
+                    None => rows_remaining_in_batch,
+                };
+
+                let batch_slice = batch.slice(offset, rows_to_write);
+                let output = current_output.as_mut().expect("output must be present");
+                output
+                    .writer
+                    .write(&batch_slice)
+                    .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+                output.num_rows += rows_to_write;
+
+                offset += rows_to_write;
+                current_output_rows += rows_to_write;
+
+                if args.rows_per_file == Some(current_output_rows) {
+                    completed_outputs.push(close_output(
+                        ruby,
+                        current_output.take().expect("output must be present"),
+                    )?);
+                    output_index += 1;
+                    current_output_rows = 0;
+                }
+            }
+        }
+    }
+
+    if let Some(output) = current_output {
+        completed_outputs.push(close_output(ruby, output)?);
+    }
+
+    persist_outputs(ruby, completed_outputs)
+}
+
+fn persist_outputs(
+    ruby: &Ruby,
+    outputs: Vec<CompletedOutput>,
+) -> Result<Vec<RepackedFile>, MagnusError> {
+    let mut repacked_files = Vec::with_capacity(outputs.len());
+    let mut persisted_paths = Vec::with_capacity(outputs.len());
+
+    for output in outputs {
+        let CompletedOutput {
+            temp_path,
+            final_path,
+            final_path_string,
+            num_rows,
+        } = output;
+
+        match temp_path.persist(&final_path) {
+            Ok(_) => {
+                persisted_paths.push(final_path);
+                repacked_files.push(RepackedFile {
+                    path: final_path_string,
+                    num_rows,
+                });
+            }
+            Err(error) => {
+                for persisted_path in persisted_paths {
+                    let _ = fs::remove_file(persisted_path);
+                }
+                return Err(MagnusError::new(
+                    ruby.exception_runtime_error(),
+                    format!(
+                        "Failed to move temporary file to '{}': {}",
+                        final_path_string, error.error
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(repacked_files)
+}
+
+fn close_output(ruby: &Ruby, output: PendingOutput) -> Result<CompletedOutput, MagnusError> {
+    let PendingOutput {
+        writer,
+        temp_file,
+        final_path,
+        final_path_string,
+        num_rows,
+    } = output;
+
+    writer
+        .close()
+        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+
+    Ok(CompletedOutput {
+        temp_path: temp_file.into_temp_path(),
+        final_path,
+        final_path_string,
+        num_rows,
+    })
+}
+
+fn create_output(
+    ruby: &Ruby,
+    args: &ParquetRepackArgs,
+    schema: SchemaRef,
+    output_index: usize,
+) -> Result<PendingOutput, MagnusError> {
+    fs::create_dir_all(&args.output_dir).map_err(|e| {
+        MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!(
+                "Failed to create output directory '{}': {}",
+                args.output_dir, e
+            ),
+        )
+    })?;
+
+    let final_path = PathBuf::from(&args.output_dir).join(format!(
+        "{}-{}.parquet",
+        args.output_file_prefix, output_index
+    ));
+    let final_path_string = final_path.to_string_lossy().into_owned();
+
+    let temp_file = NamedTempFile::new_in(&args.output_dir).map_err(|e| {
+        MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!(
+                "Failed to create temporary output file for '{}': {}",
+                final_path_string, e
+            ),
+        )
+    })?;
+
+    let file = temp_file.reopen().map_err(|e| {
+        MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!(
+                "Failed to reopen temporary output file for '{}': {}",
+                final_path_string, e
+            ),
+        )
+    })?;
+
+    let props = WriterProperties::builder()
+        .set_compression(parse_compression(ruby, args.compression.clone())?)
+        .build();
+
+    let writer = ArrowWriter::try_new(file, schema, Some(props))
+        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))?;
+
+    Ok(PendingOutput {
+        writer,
+        temp_file,
+        final_path,
+        final_path_string,
+        num_rows: 0,
+    })
+}
+
+fn validate_input_schemas(
+    ruby: &Ruby,
+    args: &ParquetRepackArgs,
+    schema: SchemaRef,
+) -> Result<(), MagnusError> {
+    for input_path in args.read_from.iter().skip(1) {
+        let input_schema = read_schema(ruby, input_path)?;
+
+        if input_schema.as_ref() != schema.as_ref() {
+            return Err(MagnusError::new(
+                ruby.exception_runtime_error(),
+                format!("Input file schema does not match first file: {}", input_path),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn read_schema(ruby: &Ruby, path: &str) -> Result<SchemaRef, MagnusError> {
+    let builder = create_reader_builder(ruby, path)?;
+    Ok(builder.schema().clone())
+}
+
+fn create_reader_builder(
+    ruby: &Ruby,
+    path: &str,
+) -> Result<ParquetRecordBatchReaderBuilder<File>, MagnusError> {
+    let file = File::open(path).map_err(|e| {
+        MagnusError::new(
+            ruby.exception_runtime_error(),
+            format!("Failed to open input file '{}': {}", path, e),
+        )
+    })?;
+
+    ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| MagnusError::new(ruby.exception_runtime_error(), e.to_string()))
+}

--- a/ext/parquet-ruby-adapter/src/repack.rs
+++ b/ext/parquet-ruby-adapter/src/repack.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use arrow_schema::SchemaRef;
 use magnus::value::ReprValue;
@@ -11,10 +12,13 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
+use parquet_core::max_batch_size_for_column_count;
 use tempfile::{NamedTempFile, TempPath};
 
 use crate::types::ParquetRepackArgs;
 use crate::utils::{parse_compression, parse_parquet_repack_args};
+
+const DEFAULT_MAX_READ_ROWS_PER_CHUNK: usize = 8192;
 
 struct RepackedFile {
     path: String,
@@ -40,6 +44,7 @@ struct RepackWithoutGvlState {
     args: Option<ParquetRepackArgs>,
     compression: Compression,
     result: Option<std::thread::Result<Result<Vec<RepackedFile>, String>>>,
+    cancelled: *const AtomicBool,
 }
 
 pub fn repack(ruby: &Ruby, args: &[Value]) -> Result<Value, MagnusError> {
@@ -63,10 +68,12 @@ fn repack_without_gvl(
     args: ParquetRepackArgs,
     compression: Compression,
 ) -> Result<Vec<RepackedFile>, MagnusError> {
+    let cancelled = AtomicBool::new(false);
     let mut state = RepackWithoutGvlState {
         args: Some(args),
         compression,
         result: None,
+        cancelled: &cancelled,
     };
 
     magnus::rb_sys::protect(|| {
@@ -74,8 +81,10 @@ fn repack_without_gvl(
             rb_sys::rb_thread_call_without_gvl(
                 Some(repack_without_gvl_trampoline),
                 (&mut state as *mut RepackWithoutGvlState).cast::<c_void>(),
-                None,
-                ptr::null_mut(),
+                Some(repack_without_gvl_unblock),
+                (&cancelled as *const AtomicBool)
+                    .cast_mut()
+                    .cast::<c_void>(),
             );
         }
         rb_sys::Qnil as rb_sys::VALUE
@@ -100,10 +109,16 @@ unsafe extern "C" fn repack_without_gvl_trampoline(data: *mut c_void) -> *mut c_
     state.result = Some(catch_unwind(AssertUnwindSafe(|| {
         let args = state.args.take().expect("repack arguments must be present");
         let compression = state.compression;
-        repack_files(&args, compression)
+        let cancelled = unsafe { &*state.cancelled };
+        repack_files(&args, compression, cancelled)
     })));
 
     ptr::null_mut()
+}
+
+unsafe extern "C" fn repack_without_gvl_unblock(data: *mut c_void) {
+    let cancelled = unsafe { &*data.cast::<AtomicBool>() };
+    cancelled.store(true, Ordering::SeqCst);
 }
 
 fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
@@ -119,9 +134,12 @@ fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
 fn repack_files(
     args: &ParquetRepackArgs,
     compression: Compression,
+    cancelled: &AtomicBool,
 ) -> Result<Vec<RepackedFile>, String> {
     let schema = read_schema(&args.read_from[0])?;
     validate_input_schemas(args, schema.clone())?;
+    let max_read_rows_per_chunk =
+        effective_max_read_rows_per_chunk(args.max_read_rows_per_chunk, schema.fields().len());
 
     let mut completed_outputs = Vec::new();
     let mut output_index = 0usize;
@@ -130,7 +148,7 @@ fn repack_files(
 
     for input_path in &args.read_from {
         let reader = create_reader_builder(input_path)?
-            .with_batch_size(args.max_read_rows_per_chunk)
+            .with_batch_size(max_read_rows_per_chunk)
             .build()
             .map_err(|e| e.to_string())?;
 
@@ -163,6 +181,7 @@ fn repack_files(
                     .writer
                     .write(&batch_slice)
                     .map_err(|e| e.to_string())?;
+                check_cancelled(cancelled)?;
                 output.num_rows += rows_to_write;
 
                 offset += rows_to_write;
@@ -183,12 +202,29 @@ fn repack_files(
         completed_outputs.push(close_output(output)?);
     }
 
+    if completed_outputs.is_empty() {
+        completed_outputs.push(close_output(create_output(args, schema, 0, compression)?)?);
+    }
+
     persist_outputs(completed_outputs)
+}
+
+fn effective_max_read_rows_per_chunk(requested: Option<usize>, column_count: usize) -> usize {
+    requested
+        .unwrap_or(DEFAULT_MAX_READ_ROWS_PER_CHUNK)
+        .min(max_batch_size_for_column_count(column_count))
+}
+
+fn check_cancelled(cancelled: &AtomicBool) -> Result<(), String> {
+    if cancelled.load(Ordering::SeqCst) {
+        Err("Parquet.repack interrupted".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 fn persist_outputs(outputs: Vec<CompletedOutput>) -> Result<Vec<RepackedFile>, String> {
     let mut repacked_files = Vec::with_capacity(outputs.len());
-    let mut persisted_paths = Vec::with_capacity(outputs.len());
 
     for output in outputs {
         let CompletedOutput {
@@ -200,16 +236,12 @@ fn persist_outputs(outputs: Vec<CompletedOutput>) -> Result<Vec<RepackedFile>, S
 
         match temp_path.persist(&final_path) {
             Ok(_) => {
-                persisted_paths.push(final_path);
                 repacked_files.push(RepackedFile {
                     path: final_path_string,
                     num_rows,
                 });
             }
             Err(error) => {
-                for persisted_path in persisted_paths {
-                    let _ = fs::remove_file(persisted_path);
-                }
                 return Err(format!(
                     "Failed to move temporary file to '{}': {}",
                     final_path_string, error.error
@@ -240,12 +272,38 @@ fn close_output(output: PendingOutput) -> Result<CompletedOutput, String> {
     })
 }
 
+fn validate_output_file_prefix(prefix: &str) -> Result<(), String> {
+    if prefix.is_empty() {
+        return Err("output_file_prefix must not be empty".to_string());
+    }
+    let p = PathBuf::from(prefix);
+    // Reject absolute paths and any path traversal components.
+    if p.is_absolute() {
+        return Err(format!(
+            "output_file_prefix must be a plain filename, not an absolute path: '{prefix}'"
+        ));
+    }
+    for component in p.components() {
+        match component {
+            std::path::Component::Normal(_) => {}
+            _ => {
+                return Err(format!(
+                    "output_file_prefix must not contain path separators or '..' components: '{prefix}'"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn create_output(
     args: &ParquetRepackArgs,
     schema: SchemaRef,
     output_index: usize,
     compression: Compression,
 ) -> Result<PendingOutput, String> {
+    validate_output_file_prefix(&args.output_file_prefix)?;
+
     fs::create_dir_all(&args.output_dir).map_err(|e| {
         format!(
             "Failed to create output directory '{}': {}",
@@ -313,4 +371,34 @@ fn create_reader_builder(path: &str) -> Result<ParquetRecordBatchReaderBuilder<F
         File::open(path).map_err(|e| format!("Failed to open input file '{}': {}", path, e))?;
 
     ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_max_read_rows_per_chunk_uses_default_when_unset() {
+        assert_eq!(
+            effective_max_read_rows_per_chunk(None, 1),
+            DEFAULT_MAX_READ_ROWS_PER_CHUNK
+        );
+    }
+
+    #[test]
+    fn effective_max_read_rows_per_chunk_is_bounded_by_schema_width() {
+        assert_eq!(
+            effective_max_read_rows_per_chunk(Some(1_000_000), 2),
+            max_batch_size_for_column_count(2)
+        );
+        assert_eq!(
+            effective_max_read_rows_per_chunk(None, 2_000),
+            max_batch_size_for_column_count(2_000)
+        );
+    }
+
+    #[test]
+    fn effective_max_read_rows_per_chunk_preserves_smaller_requests() {
+        assert_eq!(effective_max_read_rows_per_chunk(Some(64), 2_000), 64);
+    }
 }

--- a/ext/parquet-ruby-adapter/src/types.rs
+++ b/ext/parquet-ruby-adapter/src/types.rs
@@ -25,7 +25,7 @@ pub struct ParquetRepackArgs {
     pub output_file_prefix: String,
     pub output_dir: String,
     pub rows_per_file: Option<usize>,
-    pub max_read_rows_per_chunk: usize,
+    pub max_read_rows_per_chunk: Option<usize>,
     pub compression: Option<String>,
 }
 

--- a/ext/parquet-ruby-adapter/src/types.rs
+++ b/ext/parquet-ruby-adapter/src/types.rs
@@ -19,6 +19,16 @@ pub struct ParquetWriteArgs {
     pub string_cache: Option<usize>,
 }
 
+#[derive(Debug)]
+pub struct ParquetRepackArgs {
+    pub read_from: Vec<String>,
+    pub output_file_prefix: String,
+    pub output_dir: String,
+    pub rows_per_file: Option<usize>,
+    pub max_read_rows_per_chunk: usize,
+    pub compression: Option<String>,
+}
+
 /// Arguments for creating row enumerators
 pub struct RowEnumeratorArgs {
     pub rb_self: Value,

--- a/ext/parquet-ruby-adapter/src/utils.rs
+++ b/ext/parquet-ruby-adapter/src/utils.rs
@@ -1,7 +1,7 @@
 use magnus::value::ReprValue;
 use magnus::{
     scan_args::{get_kwargs, scan_args},
-    Error as MagnusError, KwArgs, Ruby, TryConvert, Value,
+    Error as MagnusError, KwArgs, RArray, Ruby, TryConvert, Value,
 };
 use parquet::basic::Compression;
 use parquet_core::{MAX_BATCH_SIZE, MAX_SAMPLE_SIZE};
@@ -11,7 +11,7 @@ use crate::string_storage::{
     StringStorageConfig, StringStorageMode, DEFAULT_SHARED_MAX_ENTRIES,
     DEFAULT_SHARED_MAX_VALUE_BYTES,
 };
-use crate::types::{ColumnEnumeratorArgs, ParquetWriteArgs, RowEnumeratorArgs};
+use crate::types::{ColumnEnumeratorArgs, ParquetRepackArgs, ParquetWriteArgs, RowEnumeratorArgs};
 
 /// Reconstruct the `string_storage:` kwarg value for an enumerator so a
 /// block-less call round-trips losslessly: a plain symbol for the mode, or a
@@ -117,6 +117,110 @@ pub fn parse_parquet_write_args(
         logger: kwargs.optional.4.flatten(),
         string_cache: parse_string_cache(ruby, kwargs.optional.5.flatten())?,
     })
+}
+
+pub fn parse_parquet_repack_args(
+    ruby: &Ruby,
+    args: &[Value],
+) -> Result<ParquetRepackArgs, MagnusError> {
+    let parsed_args = scan_args::<(Value,), (), (), (), _, ()>(args)?;
+    let (read_from,) = parsed_args.required;
+
+    let kwargs = get_kwargs::<
+        _,
+        (String,),
+        (
+            Option<Option<String>>,
+            Option<Option<usize>>,
+            Option<Option<usize>>,
+            Option<Option<String>>,
+        ),
+        (),
+    >(
+        parsed_args.keywords,
+        &["output_dir"],
+        &[
+            "output_file_prefix",
+            "rows_per_file",
+            "max_read_rows_per_chunk",
+            "compression",
+        ],
+    )?;
+
+    let read_from = parse_path_list(ruby, read_from, "read_from")?;
+    if read_from.is_empty() {
+        return Err(MagnusError::new(
+            ruby.exception_arg_error(),
+            "read_from must include at least one path",
+        ));
+    }
+
+    let rows_per_file = kwargs.optional.1.flatten();
+    if rows_per_file == Some(0) {
+        return Err(MagnusError::new(
+            ruby.exception_arg_error(),
+            "rows_per_file must be greater than 0",
+        ));
+    }
+
+    let max_read_rows_per_chunk = kwargs
+        .optional
+        .2
+        .flatten()
+        .unwrap_or(8192);
+    if max_read_rows_per_chunk == 0 {
+        return Err(MagnusError::new(
+            ruby.exception_arg_error(),
+            "max_read_rows_per_chunk must be greater than 0",
+        ));
+    }
+
+    Ok(ParquetRepackArgs {
+        read_from,
+        output_file_prefix: kwargs
+            .optional
+            .0
+            .flatten()
+            .unwrap_or_else(|| "batch".to_string()),
+        output_dir: kwargs.required.0,
+        rows_per_file,
+        max_read_rows_per_chunk,
+        compression: Some(
+            kwargs
+                .optional
+                .3
+                .flatten()
+                .unwrap_or_else(|| "zstd".to_string()),
+        ),
+    })
+}
+
+fn parse_path_list(ruby: &Ruby, value: Value, name: &str) -> Result<Vec<String>, MagnusError> {
+    if value.is_kind_of(ruby.class_string()) {
+        return Ok(vec![value.to_r_string()?.to_string()?]);
+    }
+
+    if value.is_kind_of(ruby.class_array()) {
+        let array: RArray = TryConvert::try_convert(value)?;
+        let mut paths = Vec::with_capacity(array.len());
+
+        for path_value in array {
+            if !path_value.is_kind_of(ruby.class_string()) {
+                return Err(MagnusError::new(
+                    ruby.exception_type_error(),
+                    format!("{name} must be a String or an Array of Strings"),
+                ));
+            }
+            paths.push(path_value.to_r_string()?.to_string()?);
+        }
+
+        return Ok(paths);
+    }
+
+    Err(MagnusError::new(
+        ruby.exception_type_error(),
+        format!("{name} must be a String or an Array of Strings"),
+    ))
 }
 
 fn parse_positive_bounded_usize(

--- a/ext/parquet-ruby-adapter/src/utils.rs
+++ b/ext/parquet-ruby-adapter/src/utils.rs
@@ -163,25 +163,34 @@ pub fn parse_parquet_repack_args(
         ));
     }
 
-    let max_read_rows_per_chunk = kwargs
+    let max_read_rows_per_chunk = parse_positive_bounded_usize(
+        ruby,
+        "max_read_rows_per_chunk",
+        kwargs.optional.2.flatten(),
+        MAX_BATCH_SIZE,
+    )?;
+
+    let output_file_prefix = kwargs
         .optional
-        .2
+        .0
         .flatten()
-        .unwrap_or(8192);
-    if max_read_rows_per_chunk == 0 {
+        .unwrap_or_else(|| "batch".to_string());
+    if output_file_prefix.contains('/') || output_file_prefix.contains('\\') {
         return Err(MagnusError::new(
             ruby.exception_arg_error(),
-            "max_read_rows_per_chunk must be greater than 0",
+            "output_file_prefix must not contain path separators",
+        ));
+    }
+    if std::path::Path::new(&output_file_prefix).is_absolute() {
+        return Err(MagnusError::new(
+            ruby.exception_arg_error(),
+            "output_file_prefix must not be an absolute path",
         ));
     }
 
     Ok(ParquetRepackArgs {
         read_from,
-        output_file_prefix: kwargs
-            .optional
-            .0
-            .flatten()
-            .unwrap_or_else(|| "batch".to_string()),
+        output_file_prefix,
         output_dir: kwargs.required.0,
         rows_per_file,
         max_read_rows_per_chunk,

--- a/ext/parquet/src/adapter_ffi.rs
+++ b/ext/parquet/src/adapter_ffi.rs
@@ -275,6 +275,12 @@ pub fn write_columns(args: &[Value]) -> Result<Value, MagnusError> {
     parquet_ruby_adapter::writer::write_columns(&ruby, write_args)
 }
 
+pub fn repack(args: &[Value]) -> Result<Value, MagnusError> {
+    let ruby = Ruby::get().expect("Ruby FFI entry point runs while the Ruby GVL is held");
+
+    parquet_ruby_adapter::repack::repack(&ruby, args)
+}
+
 fn reject_row_only_column_write_options(
     write_args: &parquet_ruby_adapter::types::ParquetWriteArgs,
 ) -> Result<(), MagnusError> {

--- a/ext/parquet/src/lib.rs
+++ b/ext/parquet/src/lib.rs
@@ -3,7 +3,7 @@ mod allocator;
 
 use magnus::{function, method, Error, Ruby};
 
-use crate::adapter_ffi::{each_column, each_row, write_columns, write_rows};
+use crate::adapter_ffi::{each_column, each_row, repack, write_columns, write_rows};
 use parquet_ruby_adapter::metadata::parse_metadata;
 
 /// Initializes the Ruby extension and defines methods.
@@ -19,6 +19,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     module.define_module_function("each_column", method!(each_column, -1))?;
     module.define_module_function("write_rows", function!(write_rows, -1))?;
     module.define_module_function("write_columns", function!(write_columns, -1))?;
+    module.define_module_function("repack", function!(repack, -1))?;
 
     Ok(())
 }

--- a/lib/parquet.rbi
+++ b/lib/parquet.rbi
@@ -181,7 +181,8 @@ module Parquet
   #   - `output_file_prefix`: File name prefix for outputs, default "batch"
   #   - `output_dir`: Directory where {output_file_prefix}-{n}.parquet files will be written
   #   - `rows_per_file`: Optional maximum number of rows per output file. When nil, all input rows are concatenated into one file.
-  #   - `max_read_rows_per_chunk`: Optional maximum number of rows to read per chunk, default 8192
+  #   - `max_read_rows_per_chunk`: Optional upper bound for rows to read per chunk, default 8192
+  #     and reduced for wide schemas to keep buffered value slots bounded
   #   - `compression`: Optional compression type to use, default "zstd"
   sig do
     params(

--- a/lib/parquet.rbi
+++ b/lib/parquet.rbi
@@ -175,4 +175,31 @@ module Parquet
     logger: nil
   )
   end
+
+  # Options:
+  #   - `read_from`: String path or array of paths to Parquet files with matching schemas
+  #   - `output_file_prefix`: File name prefix for outputs, default "batch"
+  #   - `output_dir`: Directory where {output_file_prefix}-{n}.parquet files will be written
+  #   - `rows_per_file`: Optional maximum number of rows per output file. When nil, all input rows are concatenated into one file.
+  #   - `max_read_rows_per_chunk`: Optional maximum number of rows to read per chunk, default 8192
+  #   - `compression`: Optional compression type to use, default "zstd"
+  sig do
+    params(
+      read_from: T.any(String, T::Array[String]),
+      output_file_prefix: T.nilable(String),
+      output_dir: String,
+      rows_per_file: T.nilable(Integer),
+      max_read_rows_per_chunk: T.nilable(Integer),
+      compression: T.nilable(String)
+    ).returns(T::Array[T::Hash[String, T.any(String, Integer)]])
+  end
+  def self.repack(
+    read_from,
+    output_file_prefix: nil,
+    output_dir:,
+    rows_per_file: nil,
+    max_read_rows_per_chunk: nil,
+    compression: nil
+  )
+  end
 end

--- a/test/repack_test.rb
+++ b/test/repack_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "bigdecimal"
+require "fileutils"
+require "tmpdir"
+
+class RepackTest < Minitest::Test
+  def setup
+    @tmp_dir = Dir.mktmpdir("parquet_repack_test")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmp_dir) if @tmp_dir && Dir.exist?(@tmp_dir)
+  end
+
+  def test_repack_concatenates_inputs_without_ruby_schema_translation
+    input_a = path("input_a.parquet")
+    input_b = path("input_b.parquet")
+    output_dir = path("output")
+    output = File.join(output_dir, "batch-0.parquet")
+    schema = {
+      fields: [
+        { name: "id", type: :int64, nullable: false },
+        { name: "name", type: :string },
+        { name: "amount", type: :decimal, precision: 10, scale: 2 },
+        { name: "created_at", type: :timestamp_micros, has_timezone: true }
+      ]
+    }
+
+    Parquet.write_rows(
+      [
+        [1, "a", BigDecimal("10.25"), Time.utc(2024, 1, 1, 12, 0, 0)],
+        [2, "b", BigDecimal("20.50"), Time.utc(2024, 1, 2, 12, 0, 0)]
+      ],
+      schema: schema,
+      write_to: input_a,
+      compression: "zstd"
+    )
+    Parquet.write_rows(
+      [[3, "c", BigDecimal("30.75"), Time.utc(2024, 1, 3, 12, 0, 0)]],
+      schema: schema,
+      write_to: input_b,
+      compression: "zstd"
+    )
+
+    counts =
+      Parquet.repack(
+        [input_a, input_b],
+        output_dir: output_dir,
+        compression: "zstd",
+        max_read_rows_per_chunk: 1
+      )
+
+    assert_equal [{ "path" => output, "num_rows" => 3 }], counts
+    assert_equal [1, 2, 3], Parquet.each_row(output).map { |row| row["id"] }
+    assert_equal schema_summary(input_a), schema_summary(output)
+  end
+
+  def test_repack_splits_outputs_on_row_boundaries_with_custom_prefix
+    input = path("input.parquet")
+    output_dir = path("output")
+    output_a = File.join(output_dir, "part-0.parquet")
+    output_b = File.join(output_dir, "part-1.parquet")
+    output_c = File.join(output_dir, "part-2.parquet")
+    schema = [{ "id" => "int64" }, { "name" => "string" }]
+    rows = 5.times.map { |index| [index, "name_#{index}"] }
+
+    Parquet.write_rows(rows, schema: schema, write_to: input)
+
+    counts =
+      Parquet.repack(
+        input,
+        output_file_prefix: "part",
+        output_dir: output_dir,
+        rows_per_file: 2,
+        max_read_rows_per_chunk: 5,
+        compression: "zstd"
+      )
+
+    assert_equal [
+      { "path" => output_a, "num_rows" => 2 },
+      { "path" => output_b, "num_rows" => 2 },
+      { "path" => output_c, "num_rows" => 1 }
+    ], counts
+    assert_equal [0, 1], Parquet.each_row(output_a).map { |row| row["id"] }
+    assert_equal [2, 3], Parquet.each_row(output_b).map { |row| row["id"] }
+    assert_equal [4], Parquet.each_row(output_c).map { |row| row["id"] }
+  end
+
+  def test_repack_rejects_mismatched_input_schemas
+    input_a = path("input_a.parquet")
+    input_b = path("input_b.parquet")
+    output_dir = path("output")
+
+    Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input_a)
+    Parquet.write_rows([["1"]], schema: [{ "id" => "string" }], write_to: input_b)
+
+    error =
+      assert_raises(RuntimeError) do
+        Parquet.repack([input_a, input_b], output_dir: output_dir, rows_per_file: 10)
+      end
+
+    assert_match(/schema does not match/, error.message)
+  end
+
+  def test_repack_rejects_invalid_sizes
+    input = path("input.parquet")
+    Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input)
+
+    assert_raises(ArgumentError) do
+      Parquet.repack(input, output_dir: path("output"), rows_per_file: 0)
+    end
+
+    assert_raises(ArgumentError) do
+      Parquet.repack(input, output_dir: path("output"), max_read_rows_per_chunk: 0)
+    end
+  end
+
+  private
+
+  def path(name)
+    File.join(@tmp_dir, name)
+  end
+
+  def schema_summary(file)
+    Parquet.metadata(file).fetch("schema").fetch("fields").map do |field|
+      {
+        "name" => field["name"],
+        "type" => field["type"],
+        "physical_type" => field["physical_type"],
+        "converted_type" => field["converted_type"],
+        "logical_type" => field["logical_type"],
+        "precision" => field["precision"],
+        "scale" => field["scale"],
+        "repetition" => field["repetition"]
+      }
+    end
+  end
+end

--- a/test/repack_test.rb
+++ b/test/repack_test.rb
@@ -117,6 +117,18 @@ class RepackTest < Minitest::Test
     end
   end
 
+  def test_repack_rejects_invalid_compression
+    input = path("input.parquet")
+    Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input)
+
+    error =
+      assert_raises(ArgumentError) do
+        Parquet.repack(input, output_dir: path("output"), compression: "invalid")
+      end
+
+    assert_match(/Invalid compression option/, error.message)
+  end
+
   private
 
   def path(name)

--- a/test/repack_test.rb
+++ b/test/repack_test.rb
@@ -117,6 +117,32 @@ class RepackTest < Minitest::Test
     end
   end
 
+  def test_repack_rejects_path_traversal_in_output_file_prefix
+    input = path("input.parquet")
+    Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input)
+
+    ["../escaped", "foo/../bar", ".."].each do |prefix|
+      error =
+        assert_raises(RuntimeError) do
+          Parquet.repack(input, output_dir: path("output"), output_file_prefix: prefix)
+        end
+      assert_match(/output_file_prefix/, error.message)
+    end
+  end
+
+  def test_repack_rejects_absolute_output_file_prefix
+    input = path("input.parquet")
+    Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input)
+
+    ["/tmp/escaped", "/etc/passwd"].each do |prefix|
+      error =
+        assert_raises(RuntimeError) do
+          Parquet.repack(input, output_dir: path("output"), output_file_prefix: prefix)
+        end
+      assert_match(/output_file_prefix/, error.message)
+    end
+  end
+
   def test_repack_rejects_invalid_compression
     input = path("input.parquet")
     Parquet.write_rows([[1]], schema: [{ "id" => "int64" }], write_to: input)


### PR DESCRIPTION
motivation: need a way to stream through parquet files and repack them (specifically resizing/rebatching parquet files). because materialising in ruby requires going through the gem schema, and read->write does not seem to be a clean $f(f^{-1}(x))$ operation

originally functionality (slightly different) implemented here (https://github.com/sutrolabs/parquet-ruby/pull/2) but then realised that we're pointing towards rubygems so here i am

concatenation is just a generalisation of the problem i figured i should add

TLDR: Adds `Parquet.repack` to stream existing Parquet files into a new set of output files without translating rows through Ruby.

- concatenating multiple input files with matching schemas
- splitting output into balanced files via `rows_per_file:`
configurable read chunk size (so streaming is roughly O(n) and we still get cache locality) and compression
- atomic-ish output behavior using temporary files before final persist


because the data crunching can take time:
```
GVL-held phase: parse Ruby args into plain Rust-owned data.
GVL-free phase: do all Parquet reading/writing/temp-file renames.
GVL-held phase: convert the Rust result into Ruby hashes/array.
```

## Tests

- concatenating inputs while preserving the readable schema shape
- splitting outputs on row boundaries
- rejecting mismatched schemas
- rejecting invalid row/chunk sizes